### PR TITLE
Use superstruct for PersistedForkChoice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "state_processing",
  "store",
  "strum",
+ "superstruct",
  "task_executor",
  "tempfile",
  "tokio",
@@ -978,36 +979,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
-dependencies = [
- "darling_core 0.12.4",
- "darling_macro 0.12.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
 dependencies = [
- "darling_core 0.13.0",
- "darling_macro 0.13.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1026,22 +1003,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
-dependencies = [
- "darling_core 0.12.4",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
 dependencies = [
- "darling_core 0.13.0",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -1597,7 +1563,7 @@ dependencies = [
 name = "eth2_ssz_derive"
 version = "0.3.0"
 dependencies = [
- "darling 0.13.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -1609,7 +1575,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "635b86d2c941bb71e7419a571e1763d65c93e51a1bafc400352e3bef6ff59fc9"
 dependencies = [
- "darling 0.13.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -5671,11 +5637,11 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "superstruct"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf7f6700d7c135cf4e4900c2cfba9a12ecad1fdc45594aad48f6b344b2589a0"
+checksum = "ecffe12af481bd0b8950f90676d61fb1e5fc33f1f1c41ce5df11e83fb509aaab"
 dependencies = [
- "darling 0.12.4",
+ "darling",
  "itertools",
  "proc-macro2",
  "quote",
@@ -5693,9 +5659,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6195,7 +6161,7 @@ dependencies = [
 name = "tree_hash_derive"
 version = "0.4.0"
 dependencies = [
- "darling 0.13.0",
+ "darling",
  "quote",
  "syn",
 ]
@@ -6206,7 +6172,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd22d128157837a4434bb51119aef11103f17bfe8c402ce688cf25aa1e608ad"
 dependencies = [
- "darling 0.13.0",
+ "darling",
  "quote",
  "syn",
 ]

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -58,6 +58,7 @@ strum = { version = "0.21.0", features = ["derive"] }
 logging = { path = "../../common/logging" }
 execution_layer = { path = "../execution_layer" }
 sensitive_url = { path = "../../common/sensitive_url" }
+superstruct = "0.3.0"
 
 [[test]]
 name = "beacon_chain_tests"

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -11,6 +11,7 @@ use ssz_derive::{Decode, Encode};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use store::{Error as StoreError, HotColdDB, ItemStore};
+use superstruct::superstruct;
 use types::{BeaconBlock, BeaconState, BeaconStateError, Checkpoint, EthSpec, Hash256, Slot};
 
 #[derive(Debug)]
@@ -338,7 +339,7 @@ where
 }
 
 /// A container which allows persisting the `BeaconForkChoiceStore` to the on-disk database.
-#[derive(Encode, Decode)]
+#[superstruct(variants(V1, V7), variant_attributes(derive(Encode, Decode)), no_enum)]
 pub struct PersistedForkChoiceStore {
     pub balances_cache: BalancesCache,
     pub time: Slot,
@@ -346,5 +347,8 @@ pub struct PersistedForkChoiceStore {
     pub justified_checkpoint: Checkpoint,
     pub justified_balances: Vec<u64>,
     pub best_justified_checkpoint: Checkpoint,
+    #[superstruct(only(V7))]
     pub proposer_boost_root: Hash256,
 }
+
+pub type PersistedForkChoiceStore = PersistedForkChoiceStoreV7;

--- a/beacon_node/beacon_chain/src/persisted_fork_choice.rs
+++ b/beacon_node/beacon_chain/src/persisted_fork_choice.rs
@@ -1,25 +1,38 @@
-use crate::beacon_fork_choice_store::PersistedForkChoiceStore as ForkChoiceStore;
-use fork_choice::PersistedForkChoice as ForkChoice;
+use crate::beacon_fork_choice_store::{PersistedForkChoiceStoreV1, PersistedForkChoiceStoreV7};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use store::{DBColumn, Error, StoreItem};
+use superstruct::superstruct;
 
-#[derive(Encode, Decode)]
+// If adding a new version you should update this type alias and fix the breakages.
+pub type PersistedForkChoice = PersistedForkChoiceV7;
+
+#[superstruct(variants(V1, V7), variant_attributes(derive(Encode, Decode)), no_enum)]
 pub struct PersistedForkChoice {
-    pub fork_choice: ForkChoice,
-    pub fork_choice_store: ForkChoiceStore,
+    pub fork_choice: fork_choice::PersistedForkChoice,
+    #[superstruct(only(V1))]
+    pub fork_choice_store: PersistedForkChoiceStoreV1,
+    #[superstruct(only(V7))]
+    pub fork_choice_store: PersistedForkChoiceStoreV7,
 }
 
-impl StoreItem for PersistedForkChoice {
-    fn db_column() -> DBColumn {
-        DBColumn::ForkChoice
-    }
+macro_rules! impl_store_item {
+    ($type:ty) => {
+        impl StoreItem for $type {
+            fn db_column() -> DBColumn {
+                DBColumn::ForkChoice
+            }
 
-    fn as_store_bytes(&self) -> Vec<u8> {
-        self.as_ssz_bytes()
-    }
+            fn as_store_bytes(&self) -> Vec<u8> {
+                self.as_ssz_bytes()
+            }
 
-    fn from_store_bytes(bytes: &[u8]) -> std::result::Result<Self, Error> {
-        Self::from_ssz_bytes(bytes).map_err(Into::into)
-    }
+            fn from_store_bytes(bytes: &[u8]) -> std::result::Result<Self, Error> {
+                Self::from_ssz_bytes(bytes).map_err(Into::into)
+            }
+        }
+    };
 }
+
+impl_store_item!(PersistedForkChoiceV1);
+impl_store_item!(PersistedForkChoiceV7);

--- a/beacon_node/beacon_chain/src/schema_change.rs
+++ b/beacon_node/beacon_chain/src/schema_change.rs
@@ -3,8 +3,7 @@ mod migrate_schema_6;
 mod migrate_schema_7;
 
 use crate::beacon_chain::{BeaconChainTypes, FORK_CHOICE_DB_KEY, OP_POOL_DB_KEY};
-use crate::persisted_fork_choice::PersistedForkChoice;
-use crate::schema_change::migrate_schema_6::LegacyPersistedForkChoice;
+use crate::persisted_fork_choice::{PersistedForkChoiceV1, PersistedForkChoiceV7};
 use crate::validator_pubkey_cache::ValidatorPubkeyCache;
 use operation_pool::{PersistedOperationPool, PersistedOperationPoolBase};
 use slog::{warn, Logger};
@@ -102,14 +101,13 @@ pub fn migrate_schema<T: BeaconChainTypes>(
         }
         // Migration for adding `execution_status` field to the fork choice store.
         (SchemaVersion(5), SchemaVersion(6)) => {
-            let fork_choice_opt = db.get_item::<LegacyPersistedForkChoice>(&FORK_CHOICE_DB_KEY)?;
+            // The top-level `PersistedForkChoice` struct is still V1 but will have its internal
+            // bytes for the fork choice updated to V6.
+            let fork_choice_opt = db.get_item::<PersistedForkChoiceV1>(&FORK_CHOICE_DB_KEY)?;
             if let Some(mut persisted_fork_choice) = fork_choice_opt {
                 migrate_schema_6::update_execution_statuses::<T>(&mut persisted_fork_choice)
                     .map_err(StoreError::SchemaMigrationError)?;
-                db.put_item::<LegacyPersistedForkChoice>(
-                    &FORK_CHOICE_DB_KEY,
-                    &persisted_fork_choice,
-                )?;
+                db.put_item::<PersistedForkChoiceV1>(&FORK_CHOICE_DB_KEY, &persisted_fork_choice)?;
             }
 
             db.store_schema_version(to)?;
@@ -130,7 +128,7 @@ pub fn migrate_schema<T: BeaconChainTypes>(
         // https://github.com/ethereum/consensus-specs/pull/2727
         // https://github.com/ethereum/consensus-specs/pull/2730
         (SchemaVersion(6), SchemaVersion(7)) => {
-            let fork_choice_opt = db.get_item::<LegacyPersistedForkChoice>(&FORK_CHOICE_DB_KEY)?;
+            let fork_choice_opt = db.get_item::<PersistedForkChoiceV1>(&FORK_CHOICE_DB_KEY)?;
             if let Some(legacy_persisted_fork_choice) = fork_choice_opt {
                 // This migrates the `PersistedForkChoiceStore`, adding the `proposer_boost_root` field.
                 let mut persisted_fork_choice = legacy_persisted_fork_choice.into();
@@ -151,7 +149,7 @@ pub fn migrate_schema<T: BeaconChainTypes>(
                 }
 
                 // Store the converted fork choice store under the same key.
-                db.put_item::<PersistedForkChoice>(&FORK_CHOICE_DB_KEY, &persisted_fork_choice)?;
+                db.put_item::<PersistedForkChoiceV7>(&FORK_CHOICE_DB_KEY, &persisted_fork_choice)?;
             }
 
             db.store_schema_version(to)?;

--- a/beacon_node/beacon_chain/src/schema_change/README.md
+++ b/beacon_node/beacon_chain/src/schema_change/README.md
@@ -50,7 +50,7 @@ Avoid names like:
 
 Previously the schema migration code would name types by the _last_ version at which they were
 valid. For example if `Foo` changed in `V9` then we would name the two variants `FooV8` and `FooV9`.
-The problem with this scheme is that if `Foo` changes again in future at say v12 then `FooV9` would
+The problem with this scheme is that if `Foo` changes again in the future at say v12 then `FooV9` would
 need to be renamed to `FooV11`, which is annoying. Using the _first_ valid version as described
 above does not have this issue.
 

--- a/beacon_node/beacon_chain/src/schema_change/README.md
+++ b/beacon_node/beacon_chain/src/schema_change/README.md
@@ -27,7 +27,7 @@ just have to handle manually resyncing any test nodes (use checkpoint sync).
 
 ## Naming Conventions
 
-Prefer to name versions of structs by _the version at which the change was introduced__. For example
+Prefer to name versions of structs by _the version at which the change was introduced_. For example
 if you add a field to `Foo` in v9, call the previous version `FooV1` (assuming this is `Foo`'s first
 migration) and write a schema change that migrates from `FooV1` to `FooV9`.
 

--- a/beacon_node/beacon_chain/src/schema_change/README.md
+++ b/beacon_node/beacon_chain/src/schema_change/README.md
@@ -1,0 +1,74 @@
+Database Schema Migrations
+====
+
+This document is an attempt to record some best practices and design conventions for applying
+database schema migrations within Lighthouse.
+
+## General Structure
+
+If you make a breaking change to an on-disk data structure you need to increment the
+`SCHEMA_VERSION` in `beacon_node/store/src/metadata.rs` and add a migration from the previous
+version to the new version.
+
+The entry-point for database migrations is in `schema_change.rs`, _not_ `migrate.rs` (which deals
+with finalization). Supporting code for a specific migration may be added in
+`schema_change/migration_schema_vX.rs`, where `X` is the version being migrated _to_.
+
+## Combining Schema Changes
+
+Schema changes may be combined if they are part of the same pull request to
+`unstable`. Once a schema version is defined in `unstable` we should not apply changes to it
+without incrementing the version. This prevents conflicts between versions that appear to be the
+same. This allows us to deploy `unstable` to nodes without having to worry about needing to resync
+because of a sneaky schema change.
+
+Changing the on-disk structure for a version _before_ it is merged to `unstable` is OK. You will
+just have to handle manually resyncing any test nodes (use checkpoint sync).
+
+## Naming Conventions
+
+Prefer to name versions of structs by _the version at which the change was introduced__. For example
+if you add a field to `Foo` in v9, call the previous version `FooV1` (assuming this is `Foo`'s first
+migration) and write a schema change that migrates from `FooV1` to `FooV9`.
+
+Prefer to use explicit version names in `schema_change.rs` and the `schema_change` module. To
+interface with the outside either:
+
+1. Define a type alias to the latest version, e.g. `pub type Foo = FooV9`, or
+2. Define a mapping from the latest version to the version used elsewhere, e.g.
+   ```rust
+   impl From<FooV9> for Foo {}
+   ```
+
+Avoid names like:
+
+* `LegacyFoo`
+* `OldFoo`
+* `FooWithoutX`
+
+## First-version vs Last-version
+
+Previously the schema migration code would name types by the _last_ version at which they were
+valid. For example if `Foo` changed in `V9` then we would name the two variants `FooV8` and `FooV9`.
+The problem with this scheme is that if `Foo` changes again in future at say v12 then `FooV9` would
+need to be renamed to `FooV11`, which is annoying. Using the _first_ valid version as described
+above does not have this issue.
+
+## Using SuperStruct
+
+If possible, consider using [`superstruct`](https://crates.io/crates/superstruct) to handle data
+structure changes between versions.
+
+* Use `superstruct(no_enum)` to avoid generating an unnecessary top-level enum.
+
+## Example
+
+A field is added to `Foo` in v9, and there are two variants: `FooV1` and `FooV9`. There is a
+migration from `FooV1` to `FooV9`. `Foo` is aliased to `FooV9`.
+
+Some time later another field is added to `Foo` in v12. A new `FooV12` is created, along with a
+migration from `FooV9` to `FooV12`. The primary `Foo` type gets re-aliased to `FooV12`. The previous
+migration from V1 to V9 shouldn't break because the schema migration refers to `FooV9` explicitly
+rather than `Foo`. Due to the re-aliasing (or re-mapping) the compiler will check every usage
+of `Foo` to make sure that it still makes sense with `FooV12`.
+

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -37,7 +37,7 @@ rand = "0.7.3"
 directory = { path = "../../common/directory" }
 regex = "1.3.9"
 strum = { version = "0.21.0", features = ["derive"] }
-superstruct = "0.2.0"
+superstruct = "0.3.0"
 
 [dependencies.libp2p]
 version = "0.41.0"

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -43,7 +43,7 @@ regex = "1.3.9"
 lazy_static = "1.4.0"
 parking_lot = "0.11.1"
 itertools = "0.10.0"
-superstruct = "0.2.0"
+superstruct = "0.3.0"
 
 [dev-dependencies]
 criterion = "0.3.3"


### PR DESCRIPTION
## Proposed Changes

First attempt at using `superstruct` in the schema migration process. I've applied it to `PersistedForkChoice` because I'm planning to change it again for https://github.com/sigp/lighthouse/pull/2849.

I've also tried to distill some design patterns for schema migrations into a doc here: https://github.com/michaelsproul/lighthouse/blob/a6dbd4cad2643b53b48e932067dfcad918331993/beacon_node/beacon_chain/src/schema_change/README.md