### PR TITLE
Decouple blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,17 +123,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-gcm"
-version = "0.8.0"
+name = "aes"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
- "aead 0.3.2",
- "aes 0.6.0",
- "cipher 0.2.5",
- "ctr 0.6.0",
- "ghash 0.3.1",
- "subtle",
+ "cfg-if",
+ "cipher 0.4.3",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -137,6 +144,20 @@ dependencies = [
  "cipher 0.3.0",
  "ctr 0.8.0",
  "ghash 0.4.4",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+dependencies = [
+ "aead 0.5.1",
+ "aes 0.8.2",
+ "cipher 0.4.3",
+ "ctr 0.9.2",
+ "ghash 0.5.0",
  "subtle",
 ]
 
@@ -205,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arbitrary"
@@ -244,11 +265,11 @@ dependencies = [
  "asn1-rs-derive 0.1.0",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.2",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -260,11 +281,11 @@ dependencies = [
  "asn1-rs-derive 0.4.0",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.2",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -325,7 +346,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -340,19 +361,20 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite 0.2.9",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -361,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -396,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-waker"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
+checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
 name = "attohttpc"
@@ -463,7 +485,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.5",
+ "itoa",
  "matchit",
  "memchr",
  "mime",
@@ -530,10 +552,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64ct"
-version = "1.5.3"
+name = "base64"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "beacon-api-client"
@@ -813,18 +841,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-slice-cast"
@@ -865,9 +881,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
@@ -925,9 +941,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "ccm"
@@ -946,7 +962,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.2",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1014,10 +1030,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.4.0"
+name = "cipher"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
 dependencies = [
  "glob",
  "libc",
@@ -1087,7 +1113,7 @@ dependencies = [
  "slot_clock",
  "store",
  "task_executor",
- "time 0.3.17",
+ "time 0.3.20",
  "timer",
  "tokio",
  "types",
@@ -1129,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1148,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "convert_case"
@@ -1193,25 +1219,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
-
-[[package]]
 name = "crc"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53757d12b596c16c78b83458d732a5d1a17ab3f53f2f7412f6fb57cc8a140ab3"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
  "crc-catalog",
 ]
 
 [[package]]
 name = "crc-catalog"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
 name = "crc32fast"
@@ -1260,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1270,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -1281,22 +1301,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -1326,6 +1346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1334,16 +1355,6 @@ name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
  "generic-array",
  "subtle",
@@ -1361,13 +1372,12 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
 dependencies = [
- "bstr",
  "csv-core",
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1383,15 +1393,6 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
-dependencies = [
- "cipher 0.2.5",
-]
-
-[[package]]
-name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
@@ -1400,13 +1401,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.2.4"
+name = "ctr"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1631ca6e3c59112501a9d87fd86f21591ff77acd31331e8a73f8d80a65bbdd71"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "nix 0.26.1",
- "windows-sys",
+ "cipher 0.4.3",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
+dependencies = [
+ "nix 0.26.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1424,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-pre.5"
+version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bc65846be335cb20f4e52d49a437b773a2c1fdb42b19fc84e79e6f6771536f"
+checksum = "8da00a7a9a4eb92a0a0f8e75660926d48f0d0f3c537e455c457bcdaa1e16b1ac"
 dependencies = [
  "cfg-if",
  "fiat-crypto",
@@ -1438,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1450,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1465,15 +1475,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1492,12 +1502,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
- "darling_core 0.14.2",
- "darling_macro 0.14.2",
+ "darling_core 0.14.3",
+ "darling_macro 0.14.3",
 ]
 
 [[package]]
@@ -1516,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1541,11 +1551,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
- "darling_core 0.14.2",
+ "darling_core 0.14.3",
  "quote",
  "syn",
 ]
@@ -1663,7 +1673,7 @@ checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
 dependencies = [
  "asn1-rs 0.3.1",
  "displaydoc",
- "nom 7.1.2",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -1677,7 +1687,7 @@ checksum = "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1"
 dependencies = [
  "asn1-rs 0.5.1",
  "displaydoc",
- "nom 7.1.2",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -1699,7 +1709,7 @@ name = "derive_arbitrary"
 version = "1.2.2"
 source = "git+https://github.com/michaelsproul/arbitrary?rev=a572fd8743012a4f1ada5ee5968b1b3619c427ba#a572fd8743012a4f1ada5ee5968b1b3619c427ba"
 dependencies = [
- "darling 0.14.2",
+ "darling 0.14.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1720,7 +1730,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
- "darling 0.14.2",
+ "darling 0.14.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1829,7 +1839,7 @@ dependencies = [
  "aes-gcm 0.9.4",
  "arrayvec",
  "delay_map",
- "enr",
+ "enr 0.6.2",
  "fnv",
  "futures",
  "hashlink",
@@ -1884,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "signature",
 ]
@@ -1938,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
@@ -1966,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -1979,10 +1989,29 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26fa0a0be8915790626d5759eb51fe47435a8eac92c2f212bd2da9aa7f30ea56"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bs58",
  "bytes",
  "ed25519-dalek",
+ "hex",
+ "k256",
+ "log",
+ "rand 0.8.5",
+ "rlp",
+ "serde",
+ "sha3 0.10.6",
+ "zeroize",
+]
+
+[[package]]
+name = "enr"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492a7e5fc2504d5fdce8e124d3e263b244a68b283cac67a69eda0cd43e0aebad"
+dependencies = [
+ "base64 0.13.1",
+ "bs58",
+ "bytes",
  "hex",
  "k256",
  "log",
@@ -2048,6 +2077,27 @@ dependencies = [
  "task_executor",
  "tokio",
  "types",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2156,7 +2206,7 @@ dependencies = [
 name = "eth2_interop_keypairs"
 version = "0.2.0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bls",
  "eth2_hashing",
  "hex",
@@ -2205,7 +2255,7 @@ dependencies = [
 name = "eth2_network_config"
 version = "0.2.0"
 dependencies = [
- "enr",
+ "enr 0.6.2",
  "eth2_config",
  "eth2_ssz",
  "kzg",
@@ -2358,7 +2408,7 @@ dependencies = [
  "async-stream",
  "blst",
  "bs58",
- "enr",
+ "enr 0.6.2",
  "hex",
  "integer-sqrt",
  "multiaddr 0.14.0",
@@ -2404,9 +2454,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "1.0.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade3e9c97727343984e1ceada4fdab11142d2ee3472d2c67027d56b1251d4f15"
+checksum = "94573efbaddb420037ffc2be6540d86ec17efd715ae8c1b4792ac6d6865b157f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -2414,8 +2464,10 @@ dependencies = [
  "elliptic-curve",
  "ethabi 18.0.0",
  "generic-array",
+ "getrandom 0.2.8",
  "hex",
  "k256",
+ "num_enum",
  "open-fastrlp",
  "rand 0.8.5",
  "rlp",
@@ -2423,6 +2475,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "tempfile",
  "thiserror",
  "tiny-keccak",
  "unicode-xid",
@@ -2430,13 +2483,14 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "1.0.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a9e0597aa6b2fdc810ff58bc95e4eeaa2c219b3e615ed025106ecb027407d8"
+checksum = "585c96fbae569931aa0fab963a010d4c98d2757028ec840809b98032d9543d18"
 dependencies = [
  "async-trait",
  "auto_impl",
- "base64",
+ "base64 0.21.0",
+ "enr 0.7.0",
  "ethers-core",
  "futures-channel",
  "futures-core",
@@ -2454,7 +2508,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.17.2",
+ "tokio-tungstenite 0.18.0",
  "tracing",
  "tracing-futures",
  "url",
@@ -2567,9 +2621,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -2711,12 +2765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
-
-[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,9 +2778,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2745,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2755,15 +2803,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2773,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -2794,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2810,21 +2858,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
 dependencies = [
  "futures-io",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "webpki 0.22.0",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-timer"
@@ -2834,9 +2882,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2918,16 +2966,6 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
-dependencies = [
- "opaque-debug",
- "polyval 0.4.5",
-]
-
-[[package]]
-name = "ghash"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
@@ -2937,10 +2975,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.27.0"
+name = "ghash"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval 0.6.0",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "git-version"
@@ -2983,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -2996,7 +3044,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tracing",
 ]
 
@@ -3063,7 +3111,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -3084,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -3139,16 +3187,6 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac 0.10.1",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
@@ -3190,13 +3228,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.5",
+ "itoa",
 ]
 
 [[package]]
@@ -3301,9 +3339,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3314,7 +3352,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.5",
+ "itoa",
  "pin-project-lite 0.2.9",
  "socket2",
  "tokio",
@@ -3331,7 +3369,7 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
  "tokio-rustls 0.23.4",
 ]
@@ -3478,7 +3516,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.2.1",
+ "parity-scale-codec 3.4.0",
 ]
 
 [[package]]
@@ -3527,6 +3565,15 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -3579,6 +3626,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,12 +3664,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
@@ -3630,12 +3681,11 @@ dependencies = [
 
 [[package]]
 name = "jemalloc-sys"
-version = "0.5.2+5.3.0-patched"
+version = "0.5.3+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134163979b6eed9564c98637b710b40979939ba351f59952708234ea11b5f3f8"
+checksum = "f9bd5d616ea7ed58b571b2e209a65759664d7fb021a0819d7a790afc67e47ca1"
 dependencies = [
  "cc",
- "fs_extra",
  "libc",
 ]
 
@@ -3651,9 +3701,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3679,7 +3729,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "pem",
  "ring",
  "serde",
@@ -3823,9 +3873,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libflate"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05605ab2bce11bcfc0e9c635ff29ef8b2ea83f29be257ee7d730cac3ee373093"
+checksum = "97822bf791bd4d5b403713886a5fbe8bf49520fe78e323b0dc480ca1a03e50b0"
 dependencies = [
  "adler32",
  "crc32fast",
@@ -3834,9 +3884,9 @@ dependencies = [
 
 [[package]]
 name = "libflate_lz77"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
+checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
 dependencies = [
  "rle-decode-fast",
 ]
@@ -3896,7 +3946,7 @@ dependencies = [
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-mplex",
- "libp2p-noise",
+ "libp2p-noise 0.41.0",
  "libp2p-plaintext",
  "libp2p-quic",
  "libp2p-swarm",
@@ -3928,7 +3978,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "multiaddr 0.14.0",
- "multihash",
+ "multihash 0.16.3",
  "multistream-select 0.11.0",
  "p256",
  "parking_lot 0.12.1",
@@ -3962,10 +4012,44 @@ dependencies = [
  "libsecp256k1",
  "log",
  "multiaddr 0.16.0",
- "multihash",
+ "multihash 0.16.3",
  "multistream-select 0.12.1",
  "once_cell",
  "p256",
+ "parking_lot 0.12.1",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "rand 0.8.5",
+ "rw-stream-sink",
+ "sec1",
+ "sha2 0.10.6",
+ "smallvec",
+ "thiserror",
+ "unsigned-varint 0.7.1",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881d9a54e97d97cdaa4125d48269d97ca8c40e5fefec6b85b30440dc60cc551f"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "log",
+ "multiaddr 0.17.0",
+ "multihash 0.17.0",
+ "multistream-select 0.12.1",
+ "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
  "prost",
@@ -4002,7 +4086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a173171c71c29bb156f98886c7c4824596de3903dadf01e2e79d2ccdcf38cd9f"
 dependencies = [
  "asynchronous-codec",
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "fnv",
@@ -4121,6 +4205,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-noise"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1216f9ec823ac7a2289b954674c54cbce81c9e45920b4fcf173018ede4295246"
+dependencies = [
+ "bytes",
+ "curve25519-dalek 3.2.0",
+ "futures",
+ "libp2p-core 0.39.0",
+ "log",
+ "once_cell",
+ "prost",
+ "prost-build",
+ "rand 0.8.5",
+ "sha2 0.10.6",
+ "snow",
+ "static_assertions",
+ "thiserror",
+ "x25519-dalek 1.1.1",
+ "zeroize",
+]
+
+[[package]]
 name = "libp2p-plaintext"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4139,21 +4246,21 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.7.0-alpha"
+version = "0.7.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e7c867e95c8130667b24409d236d37598270e6da69b3baf54213ba31ffca59"
+checksum = "5971f629ff7519f4d4889a7c981f0dc09c6ad493423cd8a13ee442de241bc8c8"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.38.0",
+ "libp2p-core 0.39.0",
  "libp2p-tls",
  "log",
  "parking_lot 0.12.1",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "thiserror",
  "tokio",
 ]
@@ -4209,16 +4316,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tls"
-version = "0.1.0-alpha"
+version = "0.1.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7905ce0d040576634e8a3229a7587cc8beab83f79db6023800f1792895defa8"
+checksum = "e9baf6f6292149e124ee737d9a79dbee783f29473fc368c7faad9d157841078a"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.38.0",
+ "libp2p-core 0.39.0",
  "rcgen 0.10.0",
  "ring",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "thiserror",
  "webpki 0.22.0",
  "x509-parser 0.14.0",
@@ -4227,9 +4334,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc"
-version = "0.4.0-alpha"
+version = "0.4.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb6cd86dd68cba72308ea05de1cebf3ba0ae6e187c40548167955d4e3970f6a"
+checksum = "db4401ec550d36f413310ba5d4bf564bb21f89fb1601cadb32b2300f8bc1eb5b"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4238,10 +4345,10 @@ dependencies = [
  "futures-timer",
  "hex",
  "if-watch",
- "libp2p-core 0.38.0",
- "libp2p-noise",
+ "libp2p-core 0.39.0",
+ "libp2p-noise 0.42.0",
  "log",
- "multihash",
+ "multihash 0.17.0",
  "prost",
  "prost-build",
  "prost-codec",
@@ -4252,7 +4359,7 @@ dependencies = [
  "thiserror",
  "tinytemplate",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "webrtc",
 ]
 
@@ -4296,7 +4403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
 dependencies = [
  "arrayref",
- "base64",
+ "base64 0.13.1",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -4483,6 +4590,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lmdb-rkv"
 version = "0.14.0"
 source = "git+https://github.com/sigp/lmdb-rs?rev=f33845c6469b94265319aac0ed5085597862c27e#f33845c6469b94265319aac0ed5085597862c27e"
@@ -4619,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -4666,9 +4779,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -4769,14 +4882,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4815,7 +4928,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "data-encoding",
- "multihash",
+ "multihash 0.16.3",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -4833,7 +4946,25 @@ dependencies = [
  "byteorder",
  "data-encoding",
  "multibase",
- "multihash",
+ "multihash 0.16.3",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.7.1",
+ "url",
+]
+
+[[package]]
+name = "multiaddr"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b53e0cc5907a5c216ba6584bf74be8ab47d6d6289f72793b2dddbf15dc3bf8c"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "multibase",
+ "multihash 0.17.0",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -4857,6 +4988,19 @@ name = "multihash"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
+dependencies = [
+ "core2",
+ "digest 0.10.6",
+ "multihash-derive",
+ "sha2 0.10.6",
+ "unsigned-varint 0.7.1",
+]
+
+[[package]]
+name = "multihash"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
 dependencies = [
  "core2",
  "digest 0.10.6",
@@ -4977,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-utils"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25af9cf0dc55498b7bd94a1508af7a78706aa0ab715a73c5169273e03c84845e"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -5004,9 +5148,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
+checksum = "260e21fbb6f3d253a14df90eb0000a6066780a15dd901a7519ce02d77a94985b"
 dependencies = [
  "bytes",
  "futures",
@@ -5086,9 +5230,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -5125,9 +5269,9 @@ checksum = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -5223,6 +5367,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5233,9 +5398,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
@@ -5260,9 +5425,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oneshot_broadcast"
@@ -5342,9 +5507,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.24.0+1.1.1s"
+version = "111.25.1+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+checksum = "1ef9a9cc6ea7d9d5e7c4a913dc4b48d0e359eddf01af1dfec96ba7064b4aba10"
 dependencies = [
  "cc",
 ]
@@ -5440,15 +5605,15 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.2.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
+checksum = "637935964ff85a605d114591d4d2c13c5d1ba2806dae97cea6bf180238a749ac"
 dependencies = [
  "arrayvec",
  "bitvec 1.0.1",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive 3.1.3",
+ "parity-scale-codec-derive 3.1.4",
  "serde",
 ]
 
@@ -5466,9 +5631,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
+checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5500,7 +5665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.5",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -5519,15 +5684,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5562,11 +5727,11 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -5586,9 +5751,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.2"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -5596,9 +5761,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -5719,7 +5884,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5730,18 +5895,7 @@ checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
-name = "polyval"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
-dependencies = [
- "cpuid-bool",
- "opaque-debug",
- "universal-hash",
+ "universal-hash 0.4.1",
 ]
 
 [[package]]
@@ -5753,7 +5907,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.4.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.0",
 ]
 
 [[package]]
@@ -5841,9 +6007,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -5882,7 +6048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83cd1b99916654a69008fd66b4f9397fbe08e6e51dfe23d4417acf5d3b8cb87c"
 dependencies = [
  "dtoa",
- "itoa 1.0.5",
+ "itoa",
  "parking_lot 0.12.1",
  "prometheus-client-derive-text-encode",
 ]
@@ -5900,9 +6066,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5910,9 +6076,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5320c680de74ba083512704acb90fe00f28f79207286a848e730c45dd73ed6"
+checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
  "bytes",
  "heck",
@@ -5945,9 +6111,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -5958,11 +6124,10 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
+checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
- "bytes",
  "prost",
 ]
 
@@ -6054,7 +6219,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "slab",
  "thiserror",
  "tinyvec",
@@ -6196,9 +6361,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -6214,7 +6379,7 @@ checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.17",
+ "time 0.3.20",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -6227,7 +6392,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.17",
+ "time 0.3.20",
  "yasna",
 ]
 
@@ -6278,21 +6443,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -6311,7 +6467,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite 0.2.9",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -6319,11 +6475,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.23.4",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -6508,7 +6665,21 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom 7.1.2",
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6517,7 +6688,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "log",
  "ring",
  "sct 0.6.1",
@@ -6526,9 +6697,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -6538,11 +6709,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -6604,7 +6775,7 @@ checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
 dependencies = [
  "cfg-if",
  "derive_more",
- "parity-scale-codec 3.2.1",
+ "parity-scale-codec 3.4.0",
  "scale-info-derive",
 ]
 
@@ -6626,7 +6797,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -6734,9 +6905,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -6747,9 +6918,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6796,9 +6967,9 @@ dependencies = [
 
 [[package]]
 name = "send_wrapper"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "sensitive_url"
@@ -6819,12 +6990,11 @@ dependencies = [
 
 [[package]]
 name = "serde-big-array"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
+checksum = "cd31f59f6fe2b0c055371bb2f16d7f0aa7d8881676c04a55b1596d1a17cd10a4"
 dependencies = [
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -6860,11 +7030,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
- "itoa 1.0.5",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -6887,7 +7057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.5",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -6937,17 +7107,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
 ]
 
 [[package]]
@@ -7024,9 +7183,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -7050,7 +7209,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -7073,9 +7232,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -7176,7 +7335,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -7221,7 +7380,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -7272,14 +7431,14 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "snow"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774d05a3edae07ce6d68ea6984f3c05e9bba8927e3dd591e3b479e5b03213d0d"
+checksum = "12ba5f4d4ff12bdb6a169ed51b7c48c0e0ac4b0b4b31012b2571e97d78d3201d"
 dependencies = [
  "aes-gcm 0.9.4",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek 4.0.0-pre.5",
+ "curve25519-dalek 4.0.0-rc.0",
  "rand_core 0.6.4",
  "ring",
  "rustc_version 0.4.0",
@@ -7303,14 +7462,14 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "flate2",
  "futures",
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.9.8",
+ "sha-1",
 ]
 
 [[package]]
@@ -7464,7 +7623,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7e94b1ec00bad60e6410e058b52f1c66de3dc5fe4d62d09b3e52bb7d3b73e25"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "crc",
  "lazy_static",
  "md-5",
@@ -7531,9 +7690,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7542,9 +7701,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -7560,9 +7719,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ddf41e393a9133c81d5f0974195366bd57082deac6e0eb02ed39b8341c2bb6"
+checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -7647,16 +7806,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -7672,9 +7830,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -7726,10 +7884,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
@@ -7755,11 +7914,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
- "itoa 1.0.5",
+ "itoa",
  "libc",
  "num_threads",
  "serde",
@@ -7775,9 +7934,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -7842,15 +8001,15 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg 1.1.0",
  "bytes",
@@ -7863,7 +8022,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7889,9 +8048,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -7914,21 +8073,21 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
  "webpki 0.22.0",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.9",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
 ]
 
 [[package]]
@@ -7946,16 +8105,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.20.7",
+ "rustls 0.20.8",
  "tokio",
  "tokio-rustls 0.23.4",
- "tungstenite 0.17.3",
+ "tungstenite 0.18.0",
  "webpki 0.22.0",
  "webpki-roots",
 ]
@@ -7978,9 +8137,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -7993,9 +8152,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -8231,14 +8390,14 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.9.8",
+ "sha-1",
  "thiserror",
  "url",
  "utf-8",
@@ -8246,19 +8405,19 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.20.7",
- "sha-1 0.10.1",
+ "rustls 0.20.8",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",
@@ -8272,7 +8431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4712ee30d123ec7ae26d1e1b218395a16c87cdbaf4b3925d170d684af62ea5e8"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "futures",
  "log",
  "md-5",
@@ -8388,9 +8547,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -8426,6 +8585,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+dependencies = [
+ "crypto-common",
  "subtle",
 ]
 
@@ -8488,9 +8657,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom 0.2.8",
 ]
@@ -8701,9 +8870,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8711,9 +8880,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -8726,9 +8895,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8738,9 +8907,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8748,9 +8917,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8761,15 +8930,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+checksum = "6db36fc0f9fb209e88fb3642590ae0205bb5a56216dabd963ba15879fe53a30b"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -8781,12 +8950,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+checksum = "0734759ae6b3b1717d661fe4f016efcfb9828f5edb4520c18eaee05af3b43be9"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -8806,9 +8988,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8821,7 +9003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f258e254752d210b84fe117b31f1e3cc9cbf04c0d747eb7f8cf7cf5e370f6d"
 dependencies = [
  "arrayvec",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "derive_more",
  "ethabi 16.0.0",
@@ -8941,7 +9123,7 @@ dependencies = [
  "sha2 0.10.6",
  "stun",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
  "tokio",
  "turn",
  "url",
@@ -8973,12 +9155,12 @@ dependencies = [
 
 [[package]]
 name = "webrtc-dtls"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7021987ae0a2ed6c8cd33f68e98e49bb6e74ffe9543310267b48a1bbe3900e5f"
+checksum = "942be5bd85f072c3128396f6e5a9bfb93ca8c1939ded735d177b7bcba9a13d05"
 dependencies = [
  "aes 0.6.0",
- "aes-gcm 0.8.0",
+ "aes-gcm 0.10.1",
  "async-trait",
  "bincode",
  "block-modes",
@@ -8988,7 +9170,7 @@ dependencies = [
  "der-parser 8.1.0",
  "elliptic-curve",
  "hkdf",
- "hmac 0.10.1",
+ "hmac 0.12.1",
  "log",
  "oid-registry 0.6.1",
  "p256",
@@ -9000,8 +9182,8 @@ dependencies = [
  "rustls 0.19.1",
  "sec1",
  "serde",
- "sha-1 0.9.8",
- "sha2 0.9.9",
+ "sha1",
+ "sha2 0.10.6",
  "signature",
  "subtle",
  "thiserror",
@@ -9014,9 +9196,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-ice"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494483fbb2f5492620871fdc78b084aed8807377f6e3fe88b2e49f0a9c9c41d7"
+checksum = "465a03cc11e9a7d7b4f9f99870558fe37a102b65b93f8045392fef7c67b39e80"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9030,7 +9212,7 @@ dependencies = [
  "tokio",
  "turn",
  "url",
- "uuid 1.2.2",
+ "uuid 1.3.0",
  "waitgroup",
  "webrtc-mdns",
  "webrtc-util",
@@ -9099,7 +9281,7 @@ dependencies = [
  "log",
  "rtcp",
  "rtp",
- "sha-1 0.9.8",
+ "sha-1",
  "subtle",
  "thiserror",
  "tokio",
@@ -9138,9 +9320,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
  "libc",
@@ -9222,19 +9404,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9244,9 +9450,9 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9256,9 +9462,9 @@ checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9268,9 +9474,9 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9280,15 +9486,15 @@ checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9298,9 +9504,9 @@ checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"
@@ -9313,13 +9519,14 @@ dependencies = [
 
 [[package]]
 name = "ws_stream_wasm"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ca1ab42f5afed7fc332b22b6e932ca5414b209465412c8cdf0ad23bc0de645"
+checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
 dependencies = [
  "async_io_stream",
  "futures",
  "js-sys",
+ "log",
  "pharos",
  "rustc_version 0.4.0",
  "send_wrapper",
@@ -9373,16 +9580,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb9bace5b5589ffead1afb76e43e34cff39cd0f3ce7e170ae0c29e53b88eb1c"
 dependencies = [
  "asn1-rs 0.3.1",
- "base64",
+ "base64 0.13.1",
  "data-encoding",
  "der-parser 7.0.0",
  "lazy_static",
- "nom 7.1.2",
+ "nom 7.1.3",
  "oid-registry 0.4.0",
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -9392,15 +9599,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
  "asn1-rs 0.5.1",
- "base64",
+ "base64 0.13.1",
  "data-encoding",
  "der-parser 8.1.0",
  "lazy_static",
- "nom 7.1.2",
+ "nom 7.1.3",
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -9447,7 +9654,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -38,15 +38,24 @@ PROFILE ?= release
 # they run for different forks.
 FORKS=phase0 altair merge capella
 
+# Extra flags for Cargo
+CARGO_INSTALL_EXTRA_FLAGS?=
+
 # Builds the Lighthouse binary in release (optimized).
 #
 # Binaries will most likely be found in `./target/release`
 install:
-	cargo install --path lighthouse --force --locked --features "$(FEATURES)" --profile "$(PROFILE)"
+	cargo install --path lighthouse --force --locked \
+		--features "$(FEATURES)" \
+		--profile "$(PROFILE)" \
+		$(CARGO_INSTALL_EXTRA_FLAGS)
 
 # Builds the lcli binary in release (optimized).
 install-lcli:
-	cargo install --path lcli --force --locked --features "$(FEATURES)" --profile "$(PROFILE)"
+	cargo install --path lcli --force --locked \
+		--features "$(FEATURES)" \
+		--profile "$(PROFILE)" \
+		$(CARGO_INSTALL_EXTRA_FLAGS)
 
 # The following commands use `cross` to build a cross-compile.
 #
@@ -124,7 +133,7 @@ run-ef-tests:
 test-beacon-chain: $(patsubst %,test-beacon-chain-%,$(FORKS))
 
 test-beacon-chain-%:
-	env FORK_NAME=$* cargo test --release --features fork_from_env -p beacon_chain
+	env FORK_NAME=$* cargo test --release --features fork_from_env,slasher/lmdb -p beacon_chain
 
 # Run the tests in the `operation_pool` crate for all known forks.
 test-op-pool: $(patsubst %,test-op-pool-%,$(FORKS))

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -38,7 +38,7 @@ clap_utils = { path = "../common/clap_utils" }
 hyper = "0.14.4"
 lighthouse_version = { path = "../common/lighthouse_version" }
 hex = "0.4.2"
-slasher = { path = "../slasher" }
+slasher = { path = "../slasher", default-features = false }
 monitoring_api = { path = "../common/monitoring_api" }
 sensitive_url = { path = "../common/sensitive_url" }
 http_api = { path = "http_api" }

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -57,7 +57,7 @@ fork_choice = { path = "../../consensus/fork_choice" }
 task_executor = { path = "../../common/task_executor" }
 derivative = "2.1.1"
 itertools = "0.10.0"
-slasher = { path = "../../slasher" }
+slasher = { path = "../../slasher", default-features = false }
 eth2 = { path = "../../common/eth2" }
 strum = { version = "0.24.0", features = ["derive"] }
 logging = { path = "../../common/logging" }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -8,8 +8,9 @@ use crate::beacon_proposer_cache::compute_proposer_duties_from_head;
 use crate::beacon_proposer_cache::BeaconProposerCache;
 use crate::blob_cache::BlobCache;
 use crate::blob_verification::{
-    AsSignedBlock, AvailabilityPendingBlock, AvailableBlock, BlobError, DataAvailabilityFailure,
-    ExecutedBlock, IntoWrappedAvailabilityPendingBlock, TryIntoAvailableBlock,
+    AsSignedBlock, AvailabilityPendingBlock, AvailabilityPendingExecutedBlock, AvailableBlock,
+    BlobError, DataAvailabilityFailure, ExecutedBlock, IntoWrappedAvailabilityPendingBlock,
+    TryIntoAvailableBlock,
 };
 use crate::block_times_cache::BlockTimesCache;
 use crate::block_verification::{
@@ -465,7 +466,7 @@ pub struct BeaconChain<T: BeaconChainTypes> {
 
 #[derive(Default)]
 pub struct AvailabilityPendingCache<T: BeaconChainTypes>(
-    FuturesUnordered<ExecutedBlock<T, AvailabilityPendingBlock<T::EthSpec>>>,
+    FuturesUnordered<AvailabilityPendingExecutedBlock<T>>,
 );
 
 impl<T: BeaconChainTypes> Stream for AvailabilityPendingCache<T> {
@@ -483,7 +484,7 @@ impl<T: BeaconChainTypes> AvailabilityPendingCache<T> {
         AvailabilityPendingCache(FuturesUnordered::new())
     }
     pub fn push(&mut self, block: ExecutedBlock<T, AvailabilityPendingBlock<T::EthSpec>>) {
-        self.0.push(block)
+        self.0.push(AvailabilityPendingExecutedBlock::new(block))
     }
 }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -442,8 +442,9 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     pub blob_cache: BlobCache<T::EthSpec>,
     pub kzg: Option<Arc<kzg::Kzg>>,
     pub pending_availability_cache_tx: Sender<ExecutedBlock<T::EthSpec>>,
-    /// Borrow a channel handle to send a blob that arrived over network to its block and listen
-    /// for error.
+    /// Clone a sender to send a blob that arrived over network to its block and listen
+    /// for error. Remove a receiver to include in an availability-pending block when the
+    /// block arrives over network.
     pub pending_blocks_tx_rx: RwLock<
         HashMap<
             Hash256,
@@ -459,18 +460,6 @@ pub struct BeaconChain<T: BeaconChainTypes> {
                     )>,
                 >,
             ),
-        >,
-    >,
-    /// Remove a channel handle to include in an availability-pending block when the block arrives
-    /// over network, so it can receive blobs and notify the sender of success or
-    /// [`BlobError::BlobAlreadyExistsAtIndex`].
-    pub pending_blocks_rx: RwLock<
-        HashMap<
-            Hash256,
-            Receiver<(
-                Arc<SignedBlobSidecar<T::EthSpec>>,
-                Option<oneshot::Sender<Result<(), BlobError<T::EthSpec>>>>,
-            )>,
         >,
     >,
 }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -480,8 +480,10 @@ impl<T: BeaconChainTypes> Stream for AvailabilityPendingCache<T> {
         availability_pending_blocks.poll_next(_cx)
     }
 }
-
 impl<T: BeaconChainTypes> AvailabilityPendingCache<T> {
+    pub fn new() -> Self {
+        AvailabilityPendingCache(FuturesUnordered::new())
+    }
     pub fn push(&mut self, block: ExecutedBlock<T, AvailabilityPendingBlock<T::EthSpec>>) {
         self.0.push(block)
     }
@@ -2716,7 +2718,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                             debug!(
                                 chain.log,
                                 "Rejected gossip block";
-                                "error" => e.to_string(),
+                               // "error" => e.to_string(), //todo (emhane)
+                                "error" => ?e,
                                 "graffiti" => graffiti_string,
                                 "slot" => slot,
                             );
@@ -2747,7 +2750,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub async fn process_block<
         A: AsSignedBlock<T>,
         I: TryIntoAvailableBlock<T>,
-        B: IntoWrappedAvailabilityPendingBlock<T> + IntoExecutionPendingBlock<T, I>,
+        B: IntoWrappedAvailabilityPendingBlock<T, I> + IntoExecutionPendingBlock<T, I>,
     >(
         self: &Arc<Self>,
         block_root: Hash256,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2821,9 +2821,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Verifies the execution payload and imports the block if it is available (all
     /// kzg-verification has completed).
-    async fn import_execution_pending_block<
-        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-    >(
+    async fn import_execution_pending_block<B: IntoAvailabilityPendingBlock<T>>(
         self: Arc<Self>,
         execution_pending_block: ExecutionPendingBlock<T, B>,
         count_unrealized: CountUnrealized,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -278,7 +278,7 @@ pub enum StateSkipConfig {
     WithoutStateRoots,
 }
 
-pub trait BeaconChainTypes: Send + Sync + Debug + 'static {
+pub trait BeaconChainTypes: Send + Sync + 'static {
     type HotStore: store::ItemStore<Self::EthSpec>;
     type ColdStore: store::ItemStore<Self::EthSpec>;
     type SlotClock: slot_clock::SlotClock;
@@ -2985,9 +2985,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // -----------------------------------------------------------------------------------------
         let current_slot = self.slot()?;
         let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
-        let block = <AvailableBlock<T> as AsSignedBlock<T>>::message(
-            &signed_block,
-        );
+        let block = signed_block.message();
         let post_exec_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_POST_EXEC_PROCESSING);
 
         // Check against weak subjectivity checkpoint.
@@ -3025,9 +3023,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Do not import a block that doesn't descend from the finalized root.
         let signed_block = check_block_is_finalized_descendant(self, &fork_choice, signed_block)?;
-        let block = <AvailableBlock<<T as BeaconChainTypes>::EthSpec> as AsSignedBlock<T>>::message(
-            &signed_block,
-        );
+        let block = signed_block.message();
 
         // Register the new block with the fork choice service.
         {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -180,6 +180,10 @@ pub const INVALID_FINALIZED_MERGE_TRANSITION_BLOCK_SHUTDOWN_REASON: &str =
 /// the block is successfully made available the matching sender is removed.
 pub const DEFAULT_PENDING_AVAILABILITY_CHANNELS: usize = 20;
 
+/// Channel with double capacity to `T::EthSpec::MaxBlobsPerBlock`, incase block
+/// comes late and duplicate blobs arrive for each index.
+pub const DEFAULT_BLOB_CHANNEL_CAPACITY: usize = EthSpec::MaxBlobsPerBlock * 2;
+
 /// Defines the behaviour when a block/block-root for a skipped slot is requested.
 pub enum WhenSlotSkipped {
     /// If the slot is a skip slot, return `None`.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -9,7 +9,7 @@ use crate::beacon_proposer_cache::BeaconProposerCache;
 use crate::blob_cache::BlobCache;
 use crate::blob_verification::{
     AsSignedBlock, AvailableBlock, BlobError, BlockWrapper, ExecutedBlock,
-    IntoWrapAvailabilityPendingBlock,
+    IntoAvailabilityPendingBlock,
 };
 use crate::block_times_cache::BlockTimesCache;
 use crate::block_verification::{
@@ -2730,7 +2730,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// Returns an `Err` if the given block was invalid, or an error was encountered during
     /// verification.
-    pub async fn process_block<A: AsSignedBlock<T>, B: IntoWrapAvailabilityPendingBlock<T, A>>(
+    pub async fn process_block<A: AsSignedBlock<T>, B: IntoAvailabilityPendingBlock<T, A>>(
         self: &Arc<Self>,
         block_root: Hash256,
         unverified_block: B,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2720,7 +2720,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Returns `Ok(block_root)` if the given `unverified_block` was successfully verified and
     /// imported into the chain.
     ///
-    /// Items that implement `IntoExecutionPendingBlock` and `IntoWrapAvailabilityPendingBlock` 
+    /// Items that implement `IntoExecutionPendingBlock` and `IntoWrapAvailabilityPendingBlock`
     /// include:
     ///
     /// - `SignedBeaconBlock`

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7,7 +7,9 @@ use crate::attester_cache::{AttesterCache, AttesterCacheKey};
 use crate::beacon_proposer_cache::compute_proposer_duties_from_head;
 use crate::beacon_proposer_cache::BeaconProposerCache;
 use crate::blob_cache::BlobCache;
-use crate::blob_verification::{AsBlock, AvailableBlock, BlobError, BlockWrapper, ExecutedBlock};
+use crate::blob_verification::{
+    AsBlock, AvailableBlock, BlobError, BlockWrapper, ExecutedBlock, IntoAvailabilityPendingBlock,
+};
 use crate::block_times_cache::BlockTimesCache;
 use crate::block_verification::{
     check_block_is_finalized_descendant, check_block_relevancy, get_block_root,
@@ -2725,7 +2727,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// Returns an `Err` if the given block was invalid, or an error was encountered during
     /// verification.
-    pub async fn process_block<B: IntoAvailabilityPendingBlock<T>>(
+    pub async fn process_block<A: AsBlock<T>, B: IntoAvailabilityPendingBlock<T, A>>(
         self: &Arc<Self>,
         block_root: Hash256,
         unverified_block: B,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -9,7 +9,7 @@ use crate::beacon_proposer_cache::BeaconProposerCache;
 use crate::blob_cache::BlobCache;
 use crate::blob_verification::{
     AsSignedBlock, AvailableBlock, BlobError, BlockWrapper, ExecutedBlock,
-    IntoAvailabilityPendingBlock, IntoWrappedAvailabilityPendingBlock,
+    IntoAvailabilityPendingBlock, IntoWrappedAvailabilityPendingBlock, TryIntoAvailableBlock,
 };
 use crate::block_times_cache::BlockTimesCache;
 use crate::block_verification::{
@@ -2938,7 +2938,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             consensus_context,
         } = executed_block;
         self.import_block(
-            block.try_into()?,
+            block.try_into_available_block(self)?,
             block_root,
             state,
             confirmed_state_roots,
@@ -2950,7 +2950,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         )
     }
 
-    /// Accepts a fully-verified block and imports it into the chain without performing any
+    /// Accepts a fully-available block and imports it into the chain without performing any
     /// additional verification.
     ///
     /// An error is returned if the block was unable to be imported. It may be partially imported

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -484,7 +484,7 @@ impl<T: BeaconChainTypes> AvailabilityPendingCache<T> {
         AvailabilityPendingCache(FuturesUnordered::new())
     }
     pub fn push(&mut self, block: ExecutedBlock<T, AvailabilityPendingBlock<T::EthSpec>>) {
-        self.0.push(AvailabilityPendingExecutedBlock::new(block))
+        self.0.push(Box::new(block).into())
     }
 }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -180,8 +180,8 @@ pub const INVALID_FINALIZED_MERGE_TRANSITION_BLOCK_SHUTDOWN_REASON: &str =
 /// the block is successfully made available the matching sender is removed.
 pub const DEFAULT_PENDING_AVAILABILITY_CHANNELS: usize = 20;
 
-/// Channel with double capacity to `T::EthSpec::MaxBlobsPerBlock`, incase block
-/// comes late and duplicate blobs arrive for each index.
+/// The next blob that comes to claim an index of a block that has already been claimed by a blob
+/// gets filtered out in processing the blob for re-gossip.
 pub const DEFAULT_BLOB_CHANNEL_CAPACITY: usize = EthSpec::MaxBlobsPerBlock;
 
 /// Defines the behaviour when a block/block-root for a skipped slot is requested.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2778,7 +2778,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // Verify and import the block.
         match import_block.await {
             // The block was successfully verified and imported. Yay.
-            Ok(block_root) => {
+            Ok(Some(block_root)) => {
                 trace!(
                     self.log,
                     "Beacon block imported";
@@ -2819,6 +2819,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 );
                 Err(other)
             }
+            Ok(None) => Err(BlockError::BlockMovedToAvailabilityPendingCache),
         }
     }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -9,7 +9,7 @@ use crate::beacon_proposer_cache::BeaconProposerCache;
 use crate::blob_cache::BlobCache;
 use crate::blob_verification::{
     AsSignedBlock, AvailableBlock, BlobError, BlockWrapper, ExecutedBlock,
-    IntoAvailabilityPendingBlock,
+    IntoWrapAvailabilityPendingBlock,
 };
 use crate::block_times_cache::BlockTimesCache;
 use crate::block_verification::{
@@ -2720,17 +2720,17 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Returns `Ok(block_root)` if the given `unverified_block` was successfully verified and
     /// imported into the chain.
     ///
-    /// Items that implement `IntoExecutionPendingBlock` include:
+    /// Items that implement `IntoExecutionPendingBlock` and `IntoWrapAvailabilityPendingBlock` 
+    /// include:
     ///
     /// - `SignedBeaconBlock`
     /// - `GossipVerifiedBlock`
-    /// - `IntoAvailabilityPendingBlock`
     ///
     /// ## Errors
     ///
     /// Returns an `Err` if the given block was invalid, or an error was encountered during
     /// verification.
-    pub async fn process_block<A: AsSignedBlock<T>, B: IntoAvailabilityPendingBlock<T, A>>(
+    pub async fn process_block<A: AsSignedBlock<T>, B: IntoWrapAvailabilityPendingBlock<T, A>>(
         self: &Arc<Self>,
         block_root: Hash256,
         unverified_block: B,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -8,8 +8,8 @@ use crate::beacon_proposer_cache::compute_proposer_duties_from_head;
 use crate::beacon_proposer_cache::BeaconProposerCache;
 use crate::blob_cache::BlobCache;
 use crate::blob_verification::{
-    AsSignedBlock, AvailabilityPendingBlock, AvailabilityPendingExecutedBlock, AvailableBlock,
-    BlobError, DataAvailabilityFailure, ExecutedBlock, IntoWrappedAvailabilityPendingBlock,
+    AvailabilityPendingBlock, AvailabilityPendingExecutedBlock, AvailableBlock, BlobError,
+    DataAvailabilityFailure, ExecutedBlock, IntoWrappedAvailabilityPendingBlock,
     TryIntoAvailableBlock,
 };
 use crate::block_times_cache::BlockTimesCache;
@@ -104,6 +104,7 @@ use state_processing::{
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fmt::Debug;
 use std::io::prelude::*;
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -277,7 +278,7 @@ pub enum StateSkipConfig {
     WithoutStateRoots,
 }
 
-pub trait BeaconChainTypes: Send + Sync + 'static {
+pub trait BeaconChainTypes: Send + Sync + Debug + 'static {
     type HotStore: store::ItemStore<Self::EthSpec>;
     type ColdStore: store::ItemStore<Self::EthSpec>;
     type SlotClock: slot_clock::SlotClock;
@@ -2984,7 +2985,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // -----------------------------------------------------------------------------------------
         let current_slot = self.slot()?;
         let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
-        let block = <AvailableBlock<<T as BeaconChainTypes>::EthSpec> as AsSignedBlock<T>>::message(
+        let block = <AvailableBlock<T> as AsSignedBlock<T>>::message(
             &signed_block,
         );
         let post_exec_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_POST_EXEC_PROCESSING);

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -182,7 +182,7 @@ pub const DEFAULT_PENDING_AVAILABILITY_CHANNELS: usize = 20;
 
 /// Channel with double capacity to `T::EthSpec::MaxBlobsPerBlock`, incase block
 /// comes late and duplicate blobs arrive for each index.
-pub const DEFAULT_BLOB_CHANNEL_CAPACITY: usize = EthSpec::MaxBlobsPerBlock * 2;
+pub const DEFAULT_BLOB_CHANNEL_CAPACITY: usize = EthSpec::MaxBlobsPerBlock;
 
 /// Defines the behaviour when a block/block-root for a skipped slot is requested.
 pub enum WhenSlotSkipped {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -8,7 +8,8 @@ use crate::beacon_proposer_cache::compute_proposer_duties_from_head;
 use crate::beacon_proposer_cache::BeaconProposerCache;
 use crate::blob_cache::BlobCache;
 use crate::blob_verification::{
-    AsBlock, AvailableBlock, BlobError, BlockWrapper, ExecutedBlock, IntoAvailabilityPendingBlock,
+    AsSignedBlock, AvailableBlock, BlobError, BlockWrapper, ExecutedBlock,
+    IntoAvailabilityPendingBlock,
 };
 use crate::block_times_cache::BlockTimesCache;
 use crate::block_verification::{
@@ -2675,7 +2676,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub async fn verify_block_for_gossip(
         self: &Arc<Self>,
         block: BlockWrapper<T::EthSpec>,
-    ) -> Result<GossipVerifiedBlock<T>, BlockError<T::EthSpec>> {
+    ) -> Result<GossipVerifiedBlock<T, B>, BlockError<T::EthSpec>> {
         let chain = self.clone();
         self.task_executor
             .clone()
@@ -2729,7 +2730,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// Returns an `Err` if the given block was invalid, or an error was encountered during
     /// verification.
-    pub async fn process_block<A: AsBlock<T>, B: IntoAvailabilityPendingBlock<T, A>>(
+    pub async fn process_block<A: AsSignedBlock<T>, B: IntoAvailabilityPendingBlock<T, A>>(
         self: &Arc<Self>,
         block_root: Hash256,
         unverified_block: B,

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -245,8 +245,7 @@ fn verify_data_availability<T: EthSpec, Bs: AsBlobSidecar<T>>(
         block_root,
         kzg_commitments,
         blob_sidecars,
-    )?
-    {
+    )? {
         return Err(BlobError::InvalidKzgProof);
     }
     Ok(())
@@ -337,8 +336,6 @@ pub trait IntoAvailabilityPendingBlock<T: BeaconChainTypes, B: AsBlock<T::EthSpe
         let rx = match existing_rx {
             Some(rx) => rx,
             None => {
-                // Channel with double capacity to T::EthSpec::MaxBlobsPerBlock, incase block
-                // comes late and duplicate blobs arrive for each index.
                 let (tx, rx) = mpsc::channel::<Arc<SignedBlobSidecar<T::EthSpec>>>(
                     DEFAULT_BLOB_CHANNEL_CAPACITY,
                 );

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -324,8 +324,8 @@ impl<T: BeaconChainTypes, B: AsSignedBlock<T::EthSpec>> IntoAvailabilityPendingB
 }
 
 pub trait IntoAvailabilityPendingBlock<T: BeaconChainTypes, B: AsSignedBlock<T::EthSpec>> {
-    /// Takes a receiver as param, on which the availability-pending block receives kzg-verified
-    /// blobs.
+    /// Wraps a block in an [`AvailabilityPendingBlock`] with a [`DataAvailabilityHandle`] to
+    /// receive blobs from the network and kzg-verify them.
     fn into_availablilty_pending_block(
         self: B,
         block_root: Hash256,
@@ -583,7 +583,7 @@ pub trait AsSignedBlock<E: EthSpec> {
 }
 
 macro_rules! impl_as_block_fn {
-    ($fn_name: ident, $return_type: ty, $(.$field: ident)*) => {
+    ($fn_name: ident, $return_type: ty, $(.$field: tt)*) => {
         fn $fn_name(&self) -> $return_type {
             self$(.$field)*.$fn_name()
         }
@@ -591,7 +591,7 @@ macro_rules! impl_as_block_fn {
 }
 
 macro_rules! impl_as_block {
-    ($type: ty, $($generic: ident: $trait: ident$(<$generic_two: ident>)*,)+ $(.$field: ident)*) => {
+    ($type: ty, $($generic: ident: $trait: ident$(<$generic_two: ident>)*,)+ $(.$field: tt)*) => {
         impl<$($generic: $trait$(<$generic_two>)*,)+> AsSignedBlock<E> for $type {
             impl_as_block_fn!(slot, Slot, $(.$field)*);
             impl_as_block_fn!(epoch, Epoch, $(.$field)*);

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -108,13 +108,13 @@ pub enum DataAvailabilityError<E: EthSpec> {
     /// Receiving an available block from pending-availability blobs cache failed.
     RecvBlobError(TryRecvError),
     /// Sending an available block from pending-availability blobs cache failed.
-    SendBlobError(SendError),
+    SendBlobError(TrySendError<E>),
     // todo(emhane): move kzg error here to take care of blob or block
 }
 
 macro_rules! impl_from_error {
-    ($(<$($generic: ident : $trait: ident,)*>)*, $from_error: ty, $to_error: ident, $to_error_variant: path) => {
-        impl$(<$($generic: $trait)*>)* From<$from_error> for $to_error$(<$($generic,)*>)* {
+    ($(<$($generic: ident : $trait: ident,)*>)*, $from_error: ty, $to_error: ty, $to_error_variant: path) => {
+        impl$(<$($generic: $trait)*>)* From<$from_error> for $to_error {
             fn from(e: $from_error) -> Self {
                 $to_error_variant(e)
             }
@@ -122,9 +122,9 @@ macro_rules! impl_from_error {
     };
 }
 
-impl_from_error!(<E: EthSpec,>, TimedOut, DataAvailabilityError, Self::TimedOut);
-impl_from_error!(<E: EthSpec,>, TryRecvError, DataAvailabilityError, Self::RecvBlobError);
-impl_from_error!(<E: EthSpec,>, TrySendError, DataAvailabilityError, Self::SendBlobError);
+impl_from_error!(<E: EthSpec,>, TimedOut, DataAvailabilityError<E>, Self::TimedOut);
+impl_from_error!(<E: EthSpec,>, TryRecvError, DataAvailabilityError<E>, Self::RecvBlobError);
+impl_from_error!(<E: EthSpec,>, TrySendError<E>, DataAvailabilityError<E>, Self::SendBlobError);
 
 impl<E: EthSpec> From<BlobReconstructionError> for BlobError<E> {
     fn from(e: BlobReconstructionError) -> Self {

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -313,6 +313,9 @@ impl<
         block_root: Hash256,
         chain: &BeaconChain<T>,
     ) -> Self::Block {
+        if self.is_availability_pending() {
+            return self;
+        }
         let ExecutionPendingBlock {
             block,
             block_root,
@@ -358,11 +361,7 @@ impl<T: BeaconChainTypes> IntoWrappedAvailabilityPendingBlock<T> for ExecutedBlo
 
 impl<
         T: BeaconChainTypes,
-        B: IntoAvailabilityPendingBlock<T>
-            + AsSignedBlock<T::EthSpec>
-            + Send
-            + Sync
-            + NotYetAvailabilityPending,
+        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
     > IntoWrappedAvailabilityPendingBlock<T> for SignatureVerifiedBlock<T, B>
 {
     type Block = SignatureVerifiedBlock<T, B>;
@@ -392,11 +391,7 @@ impl<
 
 impl<
         T: BeaconChainTypes,
-        B: IntoAvailabilityPendingBlock<T>
-            + AsSignedBlock<T::EthSpec>
-            + Send
-            + Sync
-            + NotYetAvailabilityPending,
+        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
     > IntoWrappedAvailabilityPendingBlock<T> for GossipVerifiedBlock<T, B>
 {
     type Block = GossipVerifiedBlock<T, B>;
@@ -433,6 +428,16 @@ pub trait IntoWrappedAvailabilityPendingBlock<T: BeaconChainTypes> {
         block_root: Hash256,
         chain: &BeaconChain<T>,
     ) -> Self::Block;
+}
+
+impl<T: BeaconChainTypes> IntoAvailabilityPendingBlock<T> for AvailabilityPendingBlock<T::EthSpec> {
+    fn into_availablilty_pending_block(
+        self,
+        block_root: Hash256,
+        chain: &BeaconChain<T>,
+    ) -> Result<AvailabilityPendingBlock<T::EthSpec>, DataAvailabilityFailure<T::EthSpec>> {
+        Ok(self)
+    }
 }
 
 impl<

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -610,57 +610,7 @@ impl_as_block!(SignatureVerifiedBlock<E, A>, E: EthSpec, A: AsSignedBlock<E>, .b
 impl_as_block!(AvailabilityPendingBlock<E>, E: EthSpec, .block);
 impl_as_block!(AvailabilityPendingBlock<E>, E: EthSpec, .block);
 impl_as_block!(Arc<SignedBeaconBlock<E>>, E: EthSpec,);
-
-impl<E: EthSpec> AsSignedBlock<E> for BlockWrapper<E> {
-    fn slot(&self) -> Slot {
-        match self {
-            BlockWrapper::Block(block) => block.slot(),
-            BlockWrapper::BlockAndBlobs(block, _) => block.slot(),
-        }
-    }
-    fn epoch(&self) -> Epoch {
-        match self {
-            BlockWrapper::Block(block) => block.epoch(),
-            BlockWrapper::BlockAndBlobs(block, _) => block.epoch(),
-        }
-    }
-    fn parent_root(&self) -> Hash256 {
-        match self {
-            BlockWrapper::Block(block) => block.parent_root(),
-            BlockWrapper::BlockAndBlobs(block, _) => block.parent_root(),
-        }
-    }
-    fn state_root(&self) -> Hash256 {
-        match self {
-            BlockWrapper::Block(block) => block.state_root(),
-            BlockWrapper::BlockAndBlobs(block, _) => block.state_root(),
-        }
-    }
-    fn signed_block_header(&self) -> SignedBeaconBlockHeader {
-        match &self {
-            BlockWrapper::Block(block) => block.signed_block_header(),
-            BlockWrapper::BlockAndBlobs(block, _) => block.signed_block_header(),
-        }
-    }
-    fn message(&self) -> BeaconBlockRef<E> {
-        match &self {
-            BlockWrapper::Block(block) => block.message(),
-            BlockWrapper::BlockAndBlobs(block, _) => block.message(),
-        }
-    }
-    fn as_block(&self) -> &SignedBeaconBlock<E> {
-        match &self {
-            BlockWrapper::Block(block) => &block,
-            BlockWrapper::BlockAndBlobs(block, _) => &block,
-        }
-    }
-    fn block_cloned(&self) -> Arc<SignedBeaconBlock<E>> {
-        match &self {
-            BlockWrapper::Block(block) => block.clone(),
-            BlockWrapper::BlockAndBlobs(block, _) => block.clone(),
-        }
-    }
-}
+impl_as_block!(BlockWrapper<E>, E: EthSpec, .0);
 
 impl<E: EthSpec> AsSignedBlock<E> for AvailableBlock<E> {
     fn slot(&self) -> Slot {

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -1,4 +1,6 @@
-use crate::beacon_chain::{BeaconChain, BeaconChainTypes, MAXIMUM_GOSSIP_CLOCK_DISPARITY};
+use crate::beacon_chain::{
+    BeaconChain, BeaconChainTypes, DEFAULT_BLOB_CHANNEL_CAPACITY, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
+};
 use crate::block_verification::{GossipVerifiedBlock, SignatureVerifiedBlock};
 use crate::{eth1_finalization_cache::Eth1FinalizationData, kzg_utils, BeaconChainError};
 use core::future::Future;
@@ -335,7 +337,7 @@ pub trait IntoAvailabilityPendingBlock<T: BeaconChainTypes, B: AsBlock<T::EthSpe
                 // Channel with double capacity to T::EthSpec::MaxBlobsPerBlock, incase block
                 // comes late and duplicate blobs arrive for each index.
                 let (tx, rx) = mpsc::channel::<Arc<SignedBlobSidecar<T::EthSpec>>>(
-                    T::EthSpec::MaxBlobsPerBlock * 2,
+                    DEFAULT_BLOB_CHANNEL_CAPACITY,
                 );
                 chain.pending_blobs_tx.put(block_root, tx);
                 rx

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -1,34 +1,38 @@
+use crate::beacon_chain::{BeaconChain, BeaconChainTypes, MAXIMUM_GOSSIP_CLOCK_DISPARITY};
+use crate::block_verification::{GossipVerifiedBlock, SignatureVerifiedBlock};
+use crate::{eth1_finalization_cache::Eth1FinalizationData, kzg_utils, BeaconChainError};
 use core::future::Future;
 use derivative::Derivative;
-use futures::channel::mpsc::{Receiver, RecvError as RecvBlobError, SendError};
+use fork_choice::{CountUnrealized, PayloadVerificationStatus};
+use futures::channel::{
+    mpsc,
+    mpsc::{error::RecvError as RecvBlobError, error::SendError},
+};
 use kzg::Kzg;
 use slot_clock::SlotClock;
 use ssz_types::VariableList;
-use std::{sync::Arc, task::Poll};
-use store::blob_sidecar::{BlobSidecar, SignedBlobSidecar};
-use tokio::{
-    task::JoinHandle,
-    time::{time::error::Elapsed as TimedOut, timeout, Duration, Timeout},
-};
-
-use crate::beacon_chain::{BeaconChain, BeaconChainTypes, MAXIMUM_GOSSIP_CLOCK_DISPARITY};
-use crate::block_verification::PayloadVerificationOutcome;
-use crate::{kzg_utils, BeaconChainError, BlockError};
 use state_processing::{
     per_block_processing::eip4844::eip4844::verify_kzg_commitments_against_transactions,
     ConsensusContext,
 };
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use task_executor::JoinHandle;
+use tokio::time::{error::Elapsed as TimedOut, Duration};
 use types::signed_beacon_block::BlobReconstructionError;
 use types::{
     BeaconBlockRef, BeaconStateError, EthSpec, Hash256, KzgCommitment, SignedBeaconBlock,
     SignedBeaconBlockHeader, SignedBlobSidecar, Slot, Transactions,
 };
-use types::{Epoch, ExecPayload};
+use types::{BeaconState, Blob, Epoch, ExecPayload, KzgProof};
 
-pub type SendBlobError = SendError<Arc<SignedBlobSidecar<E>>>;
+pub type SendBlobError<E: EthSpec> = SendError<Arc<SignedBlobSidecar<E>>>;
 
 #[derive(Debug)]
-pub enum BlobError<E: EthSpec, B: AsBlock<E>> {
+pub enum BlobError<E: EthSpec> {
     /// The blob sidecar is from a slot that is later than the current slot (with respect to the
     /// gossip clock disparity).
     ///
@@ -79,16 +83,34 @@ pub enum BlobError<E: EthSpec, B: AsBlock<E>> {
     /// Blobs provided for a pre-Eip4844 fork.
     InconsistentFork,
     /// Verifying availability of a block failed.
-    DataAvailabilityFailed(B, DataAvailabilityError),
+    DataAvailabilityFailed(DataAvailabilityFailed<E>),
 }
 
-pub enum DataAvailabilityError {
+#[derive(Debug)]
+pub enum DataAvailabilityFailed<E: EthSpec> {
+    /// Verifying availability of a block failed. Contains the blobs that have been received.
+    Block(
+        Arc<SignedBeaconBlock<E>>,
+        VariableList<Arc<SignedBlobSidecar<E>>, E::MaxBlobsPerBlock>,
+        DataAvailabilityError<E>,
+    ),
+    /// Verifying availability of a block that which already has a verified execution payload
+    /// failed. Contains the blobs that have been received.
+    ExecutedBlock(
+        Arc<ExecutedBlock<E>>,
+        VariableList<Arc<SignedBlobSidecar<E>>, E::MaxBlobsPerBlock>,
+        DataAvailabilityError<E>,
+    ),
+}
+
+#[derive(Debug)]
+pub enum DataAvailabilityError<E: EthSpec> {
     /// Awaiting blobs over network timed out.
     TimedOut(TimedOut),
     /// Receiving an available block from pending-availability blobs cache failed.
     RecvBlobError(RecvBlobError),
     /// Sending an available block from pending-availability blobs cache failed.
-    SendBlobError(SendBlobError),
+    SendBlobError(SendBlobError<E>),
     // todo(emhane): move kzg error here to take care of blob or block
 }
 
@@ -103,14 +125,8 @@ macro_rules! impl_from_error {
 }
 
 impl_from_error!(TimedOut, DataAvailabilityError);
-impl_from_error!(RecvAvailableBlockError, DataAvailabilityError);
-impl_from_error!(SendAvailableBlockError, DataAvailabilityError);
-
-impl From<time::error::Elapsed> for Data {
-    fn from(e: BlobReconstructionError) -> Self {
-        DataAvailabilityError
-    }
-}
+impl_from_error!(RecvBlobError, DataAvailabilityError);
+impl_from_error!(SendBlobError, DataAvailabilityError);
 
 impl From<BlobReconstructionError> for BlobError {
     fn from(e: BlobReconstructionError) -> Self {
@@ -135,14 +151,21 @@ impl From<BeaconStateError> for BlobError {
 
 /// A wrapper around a [`SignedBlobSidecar`] that indicates it has been approved for re-gossiping
 /// on the p2p network.
-pub struct GossipVerifiedBlob<T: BeaconChainTypes>(Arc<SignedBlobSidecar<T::EthSpec>>);
+pub struct GossipVerifiedBlob<T: EthSpec>(Arc<SignedBlobSidecar<T>>);
 
-pub fn validate_blob_for_gossip<T: BeaconChainTypes, Bs: AsBlobSidecar<E>>(
-    blob: Bs,
+impl<T: BeaconChainTypes> Into<Arc<SignedBlobSidecar<T>>> for GossipVerifiedBlob<T> {
+    fn into(self) -> Arc<SignedBlobSidecar<T>> {
+        self.0
+    }
+}
+
+pub fn validate_blob_for_gossip<T: BeaconChainTypes, B: AsBlock<T>>(
+    block: B,
     block_root: Hash256,
     chain: &BeaconChain<T>,
+    blob_sidecar: SignedBlobSidecar<T>,
 ) -> Result<GossipVerifiedBlob, BlobError> {
-    let blob_slot = blobs_sidecar.beacon_block_slot;
+    let blob_slot = blob_sidecar.beacon_block_slot();
     // Do not gossip or process blobs from future or past slots.
     let latest_permissible_slot = chain
         .slot_clock
@@ -155,18 +178,18 @@ pub fn validate_blob_for_gossip<T: BeaconChainTypes, Bs: AsBlobSidecar<E>>(
         });
     }
 
-    if blob_slot != block.slot() {
+    if blob_slot != block.blob_slot() {
         return Err(BlobError::SlotMismatch {
             blob_slot,
             block_slot: block.slot(),
         });
     }
-    Ok(GossipVerifiedBlob(blob))
+    Ok(GossipVerifiedBlob(blob_sidecar))
 }
 
 fn verify_blobs<E: EthSpec, B: AsBlock<E>, Bs: AsBlobSidecar<E>>(
     block: B,
-    blobs: SmallVec<[Bs; E::MaxBlobsPerBlock]>,
+    blobs: VariableList<Bs, E::MaxBlobsPerBlock>,
     kzg: Option<&Kzg>,
 ) -> Result<(), BlobError> {
     let Some(kzg) = kzg else {
@@ -198,7 +221,7 @@ fn verify_blobs<E: EthSpec, B: AsBlock<E>, Bs: AsBlobSidecar<E>>(
 }
 
 fn verify_data_availability<T: EthSpec, Bs: AsBlobSidecar<T>>(
-    blob_sidecars: SmallVec<[Bs; T::MaxBlobsPerBlock]>,
+    blob_sidecars: VariableList<Bs, T::MaxBlobsPerBlock>,
     kzg_commitments: &[KzgCommitment],
     transactions: &Transactions<T>,
     block_slot: Slot,
@@ -212,7 +235,7 @@ fn verify_data_availability<T: EthSpec, Bs: AsBlobSidecar<T>>(
     // Validatate that the kzg proof is valid against the commitments and blobs
     let kzg = kzg.ok_or(BlobError::TrustedSetupNotInitialized)?;
 
-    if !kzg_utils::validate_blobs_sidecar(
+    if !kzg_utils::validate_blob_sidecars(
         kzg,
         block_slot,
         block_root,
@@ -239,37 +262,32 @@ impl<E: EthSpec> From<Arc<SignedBeaconBlock<E>>> for BlockWrapper<E> {
     }
 }
 
-/// A wrapper over a [`SignedBlobSidecar`]. This makes no claims about data availability and
-/// should not be used in consensus. This struct is useful in networking when we want to send
-/// blocks around without consensus checks.
-#[derive(Clone, Debug, Derivative)]
-#[derivative(PartialEq, Hash(bound = "E: EthSpec"))]
-
 pub trait AsBlobSidecar<E: EthSpec> {
     fn beacon_block_root(&self) -> Hash256;
     fn beacon_block_slot(&self) -> Slot;
     fn proposer_index(&self) -> u64;
     fn block_parent_root(&self) -> Hash256;
     fn blob_index(&self) -> u64;
-    fn blob(&self) -> Blob<T>;
+    fn blob(&self) -> Blob<E>;
     fn kzg_aggregated_proof(&self) -> KzgProof;
 }
 
 macro_rules! impl_as_blob_sidecar_fn_for_signed_sidecar {
-    ($fn_name: ident, $return_type: ident) => {
-        fn $fn_name -> $return_type {
-           self.message().$fn_name()
+    ($fn_name: ident, $return_type: ident, $self: ident) => {
+        fn $fn_name() -> $return_type {
+            $self.message().$fn_name()
         }
     };
 }
+
 impl<E: EthSpec> AsBlobSidecar<E> for Arc<SignedBlobSidecar<E>> {
-    impl_as_blob_sidecar_fn_for_signed_sidecar!(beacon_block_root, Hash256);
-    impl_as_blob_sidecar_fn_for_signed_sidecar!(beacon_block_slot, Slot);
-    impl_as_blob_sidecar_fn_for_signed_sidecar!(proposer_index, u64);
-    impl_as_blob_sidecar_fn_for_signed_sidecar!(block_parent_root, Hash256);
-    impl_as_blob_sidecar_fn_for_signed_sidecar!(blob_index, u64);
-    impl_as_blob_sidecar_fn_for_signed_sidecar!(blob, Blob<E>);
-    impl_as_blob_sidecar_fn_for_signed_sidecar!(kzg_aggregated_proof, KzgProof);
+    impl_as_blob_sidecar_fn_for_signed_sidecar!(beacon_block_root, Hash256, Self);
+    impl_as_blob_sidecar_fn_for_signed_sidecar!(beacon_block_slot, Slot, Self);
+    impl_as_blob_sidecar_fn_for_signed_sidecar!(proposer_index, u64, Self);
+    impl_as_blob_sidecar_fn_for_signed_sidecar!(block_parent_root, Hash256, Self);
+    impl_as_blob_sidecar_fn_for_signed_sidecar!(blob_index, u64, Self);
+    impl_as_blob_sidecar_fn_for_signed_sidecar!(blob, Blob, Self);
+    impl_as_blob_sidecar_fn_for_signed_sidecar!(kzg_aggregated_proof, KzgProof, Self);
 }
 
 #[derive(Copy, Clone)]
@@ -278,35 +296,40 @@ pub enum DataAvailabilityCheckRequired {
     No,
 }
 
+impl<T: BeaconChainTypes> IntoAvailabilityPendingBlock<T> for GossipVerifiedBlock<T> {}
+impl<T: BeaconChainTypes> IntoAvailabilityPendingBlock<T> for SignatureVerifiedBlock<T> {}
+impl<T: BeaconChainTypes> IntoAvailabilityPendingBlock<T> for Arc<SignedBeaconBlock<T::EthSpec>> {}
+
+impl<T: BeaconChainTypes> IntoAvailabilityPendingBlock<T> for AvailabilityPendingBlock {
+    fn into_availablilty_pending_block(
+        self,
+        block_root: Hash256,
+        chain: &BeaconChain<T>,
+    ) -> AvailabilityPendingBlock<T::EthSpec> {
+        self
+    }
+}
 pub trait IntoAvailabilityPendingBlock<T: BeaconChainTypes> {
     /// Takes a receiver as param, on which the availability-pending block receives kzg-verified
     /// blobs.
     fn into_availablilty_pending_block(
         self,
         block_root: Hash256,
-        rx: Receiver<Arc<SignedBlobSidecar<T::EthSpec>>>,
         chain: &BeaconChain<T>,
-    ) -> AvailablilityPendingBlock<T::EthSpec>;
-}
+    ) -> AvailabilityPendingBlock<T::EthSpec> {
+        // If a blob receiver exists for the block root, some blobs have already arrived.
+        let existing_rx = chain.pending_blocks_rx.remove(&block_root);
+        let rx = match existing_rx {
+            Some(rx) => rx,
+            None => {
+                let (tx, rx) = mpsc::channel::<Arc<SignedBlobSidecar<T::EthSpec>>>(
+                    T::EthSpec::MaxBlobsPerBlock,
+                );
+                chain.pending_blobs_tx.put(block_root, tx);
+                rx
+            }
+        };
 
-impl<T: BeaconChainTypes> IntoAvailabilityPendingBlock<T> for BlockWrapper<T::EthSpec> {
-    fn into_availablilty_pending_block(
-        self,
-        block_root: Hash256,
-        rx: Receiver<Arc<SignedBlobSidecar<T::EthSpec>>>,
-        chain: &BeaconChain<T>,
-    ) -> AvailablilityPendingBlock<T::EthSpec> {
-        self
-    }
-}
-
-impl<T: BeaconChainTypes> IntoAvailabilityPendingBlock<T> for BlockWrapper<T::EthSpec> {
-    fn into_availablilty_pending_block(
-        self,
-        block_root: Hash256,
-        rx: Receiver<Arc<SignedBlobSidecar<T::EthSpec>>>,
-        chain: &BeaconChain<T>,
-    ) -> AvailablilityPendingBlock<T::EthSpec> {
         let block = self.block;
         let Some(data_availability_boundary) = chain.data_availability_boundary() else {
             return Ok(AvailabilityPendingBlock {
@@ -314,53 +337,74 @@ impl<T: BeaconChainTypes> IntoAvailabilityPendingBlock<T> for BlockWrapper<T::Et
                 data_availability_handle:  async { Ok(AvailableBlock(AvailableBlockInner::Block(block))) },
             })
         };
-        let data_availability_handle = if self.slot().epoch(T::EthSpec::slots_per_epoch())
-            >= boundary
-        {
-            let kzg_commitments = self.message().body().kzg_commitments();
-            let data_availability_handle = if kzg_commitments.is_empty() {
-                // check that txns match with empty kzg-commitments
-                verify_blobs(self.as_block(), SmallVec::empty(), chain.kzg)?;
-                async { Ok(AvailableBlock(AvailableBlockInner::Block(block))) }
+        let data_availability_handle =
+            if self.slot().epoch(T::EthSpec::slots_per_epoch()) >= data_availability_boundary {
+                let kzg_commitments = self.message().body().kzg_commitments();
+                let data_availability_handle = if kzg_commitments.is_empty() {
+                    // check that txns match with empty kzg-commitments
+                    verify_blobs(self.as_block(), VariableList::empty(), chain.kzg)?;
+                    async { Ok(AvailableBlock(AvailableBlockInner::Block(block))) }
+                } else {
+                    let chain = chain.clone();
+                    let block = block.clone();
+
+                    let availability_handle = chain.task_executor.spwan_handle::<Result<
+                        AvailableBlock<T::EthSpec>,
+                        BlobError,
+                    >>(
+                        async move {
+                            let blobs = VariableList::<
+                                SignedBlobSidecar<T::EthSpec>,
+                                T::EthSpec::MaxBlobsPerBlock,
+                            >::with_capcity(
+                                T::EthSpec::MaxBlobsPerBlock
+                            );
+                            loop {
+                                match rx.try_recv() {
+                                    Ok(Some(blob)) => {
+                                        blobs.push(blob);
+                                        if blobs.len() == kzg_commitments.len() {
+                                            break;
+                                        }
+                                    }
+                                    Ok(None) => {
+                                        break;
+                                    }
+                                    Err(e) => {
+                                        return BlobError::DataAvailabilityFailed(block, blobs, e)
+                                    }
+                                }
+                            }
+                            let kzg_handle = chain
+                                .task_executor
+                                .spawn_blocking_handle::<Result<(), BlobError>>(
+                                    move || {
+                                        verify_blobs(&block, blobs, chain.kzg).map_err(|e| {
+                                            BlobError::DataAvailabilityFailed(block, blobs, e)
+                                        })
+                                    },
+                                    &format!("verify_blobs_{block_root}"),
+                                );
+                            kzg_handle
+                                .await
+                                .map_err(|e| BlobError::DataAvailabilityFailed(block, blobs, e))?;
+                            chain.pending_blobs_tx.remove(&block_root);
+                            Ok(AvailableBlock(AvailableBlockInner::BlockAndBlobs(
+                                block, blobs,
+                            )))
+                        },
+                        format!("data_availability_block_{block_root}"),
+                    );
+
+                    tokio::time::timeout(
+                        Duration::from_secs(AVAILABILITY_PENDING_CACHE_ITEM_TIMEOUT),
+                        availability_handle,
+                    )
+                };
+                data_availability_handle
             } else {
-                let chain = chain.clone();
-                let block = block.clone();
-
-                let availability_handle = chain.task_executor.spwan_handle::<Result<
-                    AvailableBlock<T::EthSpec>,
-                    BlobError,
-                >>(
-                    async move {
-                        let blobs = SmallVec::<
-                            [BlobSidecar<T::EthSpec>; T::EthSpec::MaxBlobsPerBlock],
-                        >::new();
-                        for _ in kzg_commitments.len() {
-                            blobs.push(rx.recv()?);
-                        }
-                        let kzg_handle = executor.spawn_blocking_handle::<Result<(), BlobError>>(
-                            move || {
-                                verify_blobs(&block, blobs, chain.kzg)?;
-                            },
-                            &format!("verify_blobs_{block_root}"),
-                        );
-                        kzg_handle.await?;
-                        chain.pending_blobs_tx.remove(&block_root);
-                        Ok(AvailableBlock(AvailableBlockInner::BlockAndBlobs(
-                            block, blobs,
-                        )))
-                    },
-                    format!("data_availability_block_{block_root}"),
-                );
-
-                tokio::time::timeout(
-                    Duration::from_secs(AVAILABILITY_PENDING_CACHE_ITEM_TIMEOUT),
-                    availability_handle,
-                )
+                async { Ok(AvailableBlock(AvailableBlockInner::Block(block))) }
             };
-            data_availability_handle
-        } else {
-            async { Ok(AvailableBlock(AvailableBlockInner::Block(block))) }
-        };
         Ok(AvailabilityPendingBlock {
             block,
             data_availability_handle,
@@ -384,7 +428,7 @@ impl<E: EthSpec> Future for AvailabilityPendingBlock<E> {
 
 /// Used to await blobs from the network.
 type DataAvailabilityHandle<E: EthSpec> =
-    impl Future<Output = Result<AvailableBlock<E>, BlobError>>;
+    JoinHandle<Result<AvailableBlock<E>, DataAvailabilityFailed<E>>>;
 
 /// A wrapper over a [`SignedBeaconBlock`] and its blobs if it has any. An [`AvailableBlock`] has
 /// passed any required data availability checks and should be used in consensus. This newtype
@@ -403,12 +447,12 @@ enum AvailableBlockInner<E: EthSpec> {
     /// The container for any block which has blobs and the blobs have been verified.
     BlockAndBlobs(
         Arc<SignedBeaconBlock<E>>,
-        VariableList<BlobSidecar<E>, E::MaxBlobsPerBlock>,
+        VariableList<SignedBlobSidecar<E>, E::MaxBlobsPerBlock>,
     ),
 }
 
 impl<E: EthSpec> AvailableBlock<E> {
-    pub fn blobs(&self) -> Option<Arc<BlobsSidecar<E>>> {
+    pub fn blobs(&self) -> Option<Arc<SignedBlobSidecar<E>>> {
         match &self.0 {
             AvailableBlockInner::Block(_) => None,
             AvailableBlockInner::BlockAndBlobs(block_blobs_pair) => {
@@ -417,7 +461,12 @@ impl<E: EthSpec> AvailableBlock<E> {
         }
     }
 
-    pub fn deconstruct(self) -> (Arc<SignedBeaconBlock<E>>, Option<Arc<BlobsSidecar<E>>>) {
+    pub fn deconstruct(
+        self,
+    ) -> (
+        Arc<SignedBeaconBlock<E>>,
+        Option<Arc<SignedBlobsSidecar<E>>>,
+    ) {
         match self.0 {
             AvailableBlockInner::Block(block) => (block, None),
             AvailableBlockInner::BlockAndBlobs(block_blobs_pair) => {
@@ -440,7 +489,7 @@ impl<E: EthSpec> TryInto<AvailableBlock<E>> for &AvailabilityPendingBlock<E> {
         match self.poll() {
             Poll::Pending => Err(BlobError::PendingAvailability),
             Poll::Ready(Ok(available_block)) => Ok(available_block),
-            Poll::Ready(Err(e)) => Err(BlobError::DataAvailabilityFailed(self.clone(), e)),
+            Poll::Ready(Err(e)) => Err(e),
         }
     }
 }
@@ -450,38 +499,32 @@ pub const AVAILABILITY_PENDING_CACHE_ITEM_TIMEOUT: u64 = 5;
 
 /// A block that has passed payload verification and is waiting for its blobs via the handle on
 /// [`AvailabilityPendingBlock`].
-pub struct ExecutedBlock<E: EthSpec, B: TryInto<AvailableBlock<E>>> {
+pub struct ExecutedBlock<E: EthSpec> {
     block_root: Hash256,
-    block: B,
+    block: AvailabilityPendingBlock<E>,
     state: BeaconState<E>,
     confirmed_state_roots: Vec<Hash256>,
     payload_verification_status: PayloadVerificationStatus,
     count_unrealized: CountUnrealized,
-    parent_block: SignedBeaconBlock,
+    parent_block: SignedBeaconBlock<E>,
     parent_eth1_finalization_data: Eth1FinalizationData,
     consensus_context: ConsensusContext<E>,
 }
 
-impl<E: EthSpec, B: TryInto<AvailableBlock<E>>> Future for ExecutedBlock<E, B> {
+impl<E: EthSpec, B: TryInto<AvailableBlock<E>>> Future for ExecutedBlock<E> {
     type Output = Result<Self, BlobError>;
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.block.poll() {
+        let availability_state = self.block.poll();
+        match availability_state {
             Poll::Pending => Poll::Pending,
-            Poll::Ready(Ok(available_block)) => {
-                ExecutedBlock {
-                    block_root,
-                    block: available_block,
-                    state,
-                    confirmed_state_roots,
-                    payload_verification_status,
-                    count_unrealized,
-                    parent_block,
-                    parent_eth1_finalization_data,
-                    consensus_context,
-                } = self;
-                Poll::Ready(Ok(executed_block))
-            }
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+            Poll::Ready(Ok(available_block)) => Poll::Ready(Ok(self)),
+            Poll::Ready(Err(BlobError::DataAvailabilityFailed(DataAvailabilityFailed::Block(
+                _,
+                blobs,
+                e,
+            )))) => Poll::Ready(Err(BlobError::DataAvailabilityFailed(
+                DataAvailabilityFailed::ExecutedBlock(self, blobs, e),
+            ))),
         }
     }
 }

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -684,7 +684,6 @@ macro_rules! impl_as_signed_block {
     };
 }
 
-impl_as_signed_block!(Arc<SignedBeaconBlock<E>>, E: EthSpec,);
 impl_as_signed_block!(GossipVerifiedBlock<E, A, B>, E: EthSpec, A: AsSignedBlock<E,> + Send + Sync, B: IntoAvailabilityPendingBlock<E, A,>, .block);
 impl_as_signed_block!(AvailabilityPendingBlock<E>, E: EthSpec, .block);
 impl_as_signed_block!(
@@ -701,3 +700,18 @@ impl_as_signed_block!(
     Self::Block,
     Self::BlockAndBlobs
 );
+
+impl<E: EthSpec> AsSignedBlock<E> for Arc<SignedBeaconBlock<E>> {
+    impl_as_signed_block_fn!(slot, Slot,);
+    impl_as_signed_block_fn!(epoch, Epoch,);
+    impl_as_signed_block_fn!(parent_root, Hash256,);
+    impl_as_signed_block_fn!(state_root, Hash256,);
+    impl_as_signed_block_fn!(signed_block_header, SignedBeaconBlockHeader,);
+    impl_as_signed_block_fn!(message, BeaconBlockRef<E>,);
+    fn as_block(&self) -> &SignedBeaconBlock<E> {
+        &*self
+    }
+    fn block_cloned(&self) -> Arc<SignedBeaconBlock<E>> {
+        self.clone()
+    }
+}

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -103,8 +103,6 @@ pub enum BlobError<E: EthSpec> {
     SendBlob(TrySendError<Arc<SignedBlobSidecar<E>>>),
     /// Spawning threads failed.
     TaskExecutor,
-    /// Mismatch between blob channel handles for a block.
-    ChannelHandleMismatch,
 }
 
 #[derive(Debug, Clone)]

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -118,6 +118,7 @@ pub enum DataAvailabilityFailure<E: EthSpec> {
     ),
 }
 
+#[macro_export]
 macro_rules! impl_from_error {
     ($(<$($generic: ident : $trait: ident,)*>)*, $from_error: ty, $to_error: ty, $to_error_variant: path) => {
         impl$(<$($generic: $trait)*>)* From<$from_error> for $to_error {

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -323,6 +323,7 @@ impl<T: BeaconChainTypes, B: AsBlock<T::EthSpec>> IntoAvailabilityPendingBlock<T
         self
     }
 }
+
 pub trait IntoAvailabilityPendingBlock<T: BeaconChainTypes, B: AsBlock<T::EthSpec>> {
     /// Takes a receiver as param, on which the availability-pending block receives kzg-verified
     /// blobs.

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -216,6 +216,16 @@ pub trait IntoAvailabilityPendingBlock<T: BeaconChainTypes> {
     ) -> AvailablilityPendingBlock<T::EthSpec>;
 }
 
+impl<T: BeaconChainTypes> IntoAvailabilityPendingBlock<T> for AvailabilityPendingBlock<T::EthSpec> {
+    fn into_availablilty_pending_block(
+        self,
+        block_root: Hash256,
+        chain: &BeaconChain<T>,
+    ) -> AvailablilityPendingBlock<T::EthSpec> {
+        self
+    }
+}
+
 impl<T: BeaconChainTypes> IntoAvailabilityPendingBlock<T> for BlockWrapper<T::EthSpec> {
     fn into_availablilty_pending_block(
         self,
@@ -266,7 +276,7 @@ enum AvailableBlockInner<E: EthSpec> {
     /// The container for any block which requires a data availability check at time of
     /// construction.
     BlockAndBlobs(
-        AvailableBlockAndBlobs<E>,
+        Arc<SignedBeaconBlock<E>>,
         VariableList<SignedBlobSidecar<E>, E::MaxBlobsPerBlock>,
     ),
 }

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -161,7 +161,7 @@ pub fn validate_blob_for_gossip<T: BeaconChainTypes, Bs: AsBlobSidecar<E>>(
             block_slot: block.slot(),
         });
     }
-    GossipVerifiedBlob(blob)
+    Ok(GossipVerifiedBlob(blob))
 }
 
 fn verify_blobs<E: EthSpec, B: AsBlock<E>, Bs: AsBlobSidecar<E>>(

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -245,8 +245,7 @@ fn verify_data_availability<T: EthSpec, Bs: AsBlobSidecar<T>>(
         block_root,
         kzg_commitments,
         blob_sidecars,
-    )
-    .map_err(BlobError::KzgError)?
+    )?
     {
         return Err(BlobError::InvalidKzgProof);
     }

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -627,7 +627,7 @@ pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: IntoAvailabilityPendin
     consensus_context: ConsensusContext<T::EthSpec>,
 }
 
-impl_as_signed_block!(SignatureVerifiedBlock<T, B>, .block, T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T,> + AsSignedBlock<E,> + Send + Sync);
+impl_as_signed_block!(SignatureVerifiedBlock<T, B>, .block, T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T,>);
 
 /// Used to await the result of executing payload with a remote EE.
 type PayloadVerificationHandle<E> =

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -45,7 +45,7 @@
 //! ```
 use crate::blob_verification::{
     validate_blob_for_gossip, AsBlock, AvailabilityPendingBlock, AvailableBlock, BlobError,
-    BlockWrapper, IntoAvailableBlock, IntoBlockWrapper,
+    BlockWrapper, IntoAvailablilityPendingBlock, IntoBlockWrapper,
 };
 use crate::eth1_finalization_cache::Eth1FinalizationData;
 use crate::execution_payload::{
@@ -679,7 +679,7 @@ pub struct ExecutionPendingBlock<
 /// Used to allow functions to accept blocks at various stages of verification.
 pub trait IntoExecutionPendingBlock<
     T: BeaconChainTypes,
-    B: IntoAvailableBlock = AvailableBlock<T::EthSpec>,
+    B: IntoAvailablilityPendingBlock = AvailableBlock<T::EthSpec>,
 >: Sized
 {
     fn into_execution_pending_block(

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -657,6 +657,8 @@ pub struct GossipVerifiedBlock<T: BeaconChainTypes, B: TryIntoAvailableBlock<T>>
     consensus_context: ConsensusContext<T::EthSpec>,
 }
 
+impl_as_signed_block!(B, GossipVerifiedBlock<T, B>, .block, B: TryIntoAvailableBlock<T,>);
+
 /// A wrapper around a `SignedBeaconBlock` that indicates that all signatures (except the deposit
 /// signatures) have been verified.
 pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: TryIntoAvailableBlock<T>> {
@@ -694,6 +696,8 @@ pub struct ExecutionPendingBlock<T: BeaconChainTypes, B: TryIntoAvailableBlock<T
     pub consensus_context: ConsensusContext<T::EthSpec>,
     pub payload_verification_handle: PayloadVerificationHandle<T::EthSpec>,
 }
+
+impl_as_signed_block!(B, ExecutionPendingBlock<T, B>, .block, B: TryIntoAvailableBlock<T,>);
 
 /// Implemented on types that can be converted into a `ExecutionPendingBlock`.
 ///

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -628,8 +628,8 @@ pub fn signature_verify_chain_segment<T: BeaconChainTypes>(
 /// the p2p network.
 #[derive(Derivative)]
 #[derivative(Debug(bound = "T: BeaconChainTypes"))]
-pub struct GossipVerifiedBlock<T: BeaconChainTypes> {
-    pub block: AvailabilityPendingBlock<T::EthSpec>,
+pub struct GossipVerifiedBlock<T: BeaconChainTypes, B: AsBlock<T::EthSpec>> {
+    pub block: B,
     pub block_root: Hash256,
     parent: Option<PreProcessingSnapshot<T::EthSpec>>,
     consensus_context: ConsensusContext<T::EthSpec>,
@@ -637,7 +637,7 @@ pub struct GossipVerifiedBlock<T: BeaconChainTypes> {
 
 /// A wrapper around a `SignedBeaconBlock` that indicates that all signatures (except the deposit
 /// signatures) have been verified.
-pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: TryInto<AvailableBlock<T::EthSpec>>> {
+pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: AsBlock<T::EthSpec>> {
     block: B,
     block_root: Hash256,
     parent: Option<PreProcessingSnapshot<T::EthSpec>>,
@@ -660,7 +660,7 @@ type PayloadVerificationHandle<E> =
 /// Note: a `ExecutionPendingBlock` is not _forever_ valid to be imported, it may later become invalid
 /// due to finality or some other event. A `ExecutionPendingBlock` should be imported into the
 /// `BeaconChain` immediately after it is instantiated.
-pub struct ExecutionPendingBlock<T: BeaconChainTypes, B: TryInto<AvailableBlock, T::EthSpec>> {
+pub struct ExecutionPendingBlock<T: BeaconChainTypes, B: AsBlock<T::EthSpec>> {
     pub block: B,
     pub block_root: Hash256,
     pub state: BeaconState<T::EthSpec>,
@@ -674,9 +674,7 @@ pub struct ExecutionPendingBlock<T: BeaconChainTypes, B: TryInto<AvailableBlock,
 /// Implemented on types that can be converted into a `ExecutionPendingBlock`.
 ///
 /// Used to allow functions to accept blocks at various stages of verification.
-pub trait IntoExecutionPendingBlock<T: BeaconChainTypes, B: TryInto<AvailableBlock, T::EthSpec>>:
-    Sized
-{
+pub trait IntoExecutionPendingBlock<T: BeaconChainTypes, B: AsBlock<T::EthSpec>>: Sized {
     fn into_execution_pending_block(
         self: B,
         block_root: Hash256,

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -566,7 +566,7 @@ fn process_block_slash_info<T: BeaconChainTypes>(
 /// will be returned.
 pub fn signature_verify_chain_segment<T: BeaconChainTypes, B: TryIntoAvailableBlock<T>>(
     mut chain_segment: Vec<(Hash256, B)>,
-    chain: &BeaconChain<T>,
+    chain: &Arc<BeaconChain<T>>,
 ) -> Result<
     Vec<SignatureVerifiedBlock<T, AvailabilityPendingBlock<T::EthSpec>>>,
     BlockError<T::EthSpec>,

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -644,7 +644,7 @@ pub struct GossipVerifiedBlock<T: BeaconChainTypes, B: TryIntoAvailableBlock<T>>
     consensus_context: ConsensusContext<T::EthSpec>,
 }
 
-impl_as_signed_block!(B, GossipVerifiedBlock<T, B>, .block, B: TryIntoAvailableBlock<T,>);
+impl_as_signed_block!(B: TryIntoAvailableBlock<T,>, GossipVerifiedBlock<T, B>, B, .block);
 
 impl<T: BeaconChainTypes> IntoWrappedAvailabilityPendingBlock<T>
     for GossipVerifiedBlock<T, AvailabilityPendingBlock<T::EthSpec>>
@@ -696,7 +696,7 @@ pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: TryIntoAvailableBlock<
     consensus_context: ConsensusContext<T::EthSpec>,
 }
 
-impl_as_signed_block!(B, SignatureVerifiedBlock<T, B>, .block, B: TryIntoAvailableBlock<T,>);
+impl_as_signed_block!(B: TryIntoAvailableBlock<T,>, SignatureVerifiedBlock<T, B>, B, .block);
 
 impl<T: BeaconChainTypes> IntoWrappedAvailabilityPendingBlock<T>
     for SignatureVerifiedBlock<T, AvailabilityPendingBlock<T::EthSpec>>
@@ -766,7 +766,7 @@ pub struct ExecutionPendingBlock<T: BeaconChainTypes, B: TryIntoAvailableBlock<T
     pub payload_verification_handle: PayloadVerificationHandle<T::EthSpec>,
 }
 
-impl_as_signed_block!(B, ExecutionPendingBlock<T, B>, .block, B: TryIntoAvailableBlock<T,>);
+impl_as_signed_block!(B: TryIntoAvailableBlock<T,>, ExecutionPendingBlock<T, B>, B, .block);
 
 impl<T: BeaconChainTypes> IntoWrappedAvailabilityPendingBlock<T>
     for ExecutionPendingBlock<T, AvailabilityPendingBlock<T::EthSpec>>

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -638,7 +638,7 @@ pub struct GossipVerifiedBlock<T: BeaconChainTypes, B: AsBlock<T::EthSpec>> {
 /// A wrapper around a `SignedBeaconBlock` that indicates that all signatures (except the deposit
 /// signatures) have been verified.
 pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: AsBlock<T::EthSpec>> {
-    block: B,
+    pub block: B,
     block_root: Hash256,
     parent: Option<PreProcessingSnapshot<T::EthSpec>>,
     consensus_context: ConsensusContext<T::EthSpec>,

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -62,7 +62,7 @@ use crate::{
     },
     metrics, BeaconChain, BeaconChainError, BeaconChainTypes,
 };
-use crate::{impl_as_signed_block, impl_as_signed_block_fn, impl_from_error};
+use crate::{impl_as_signed_block, impl_as_signed_block_fn, impl_wrap_type_in_variant};
 use derivative::Derivative;
 use eth2::types::EventKind;
 use execution_layer::PayloadStatus;
@@ -291,8 +291,8 @@ pub enum BlockError<T: EthSpec> {
     BlobValidation(BlobError<T>),
 }
 
-impl_from_error!(<T: EthSpec,>, BlobError<T>, BlockError<T>, Self::BlobValidation);
-impl_from_error!(<T: EthSpec,>, DataAvailabilityFailure<T>, BlockError<T>, Self::DataAvailability);
+impl_wrap_type_in_variant!(<T: EthSpec,>, BlobError<T>, BlockError<T>, Self::BlobValidation);
+impl_wrap_type_in_variant!(<T: EthSpec,>, DataAvailabilityFailure<T>, BlockError<T>, Self::DataAvailability);
 
 /// Returned when block validation failed due to some issue verifying
 /// the execution payload.

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -44,7 +44,7 @@
 //!
 //! ```
 use crate::blob_verification::{
-    AsSignedBlock, AvailabilityPendingBlock, AvailableBlock, BlobError, DataAvailabilityFailure,
+    AvailabilityPendingBlock, AvailableBlock, BlobError, DataAvailabilityFailure,
     IntoWrappedAvailabilityPendingBlock, SomeAvailabilityBlock, TryIntoAvailableBlock,
 };
 use crate::eth1_finalization_cache::Eth1FinalizationData;
@@ -94,9 +94,9 @@ use tree_hash::TreeHash;
 use types::signed_beacon_block::BlobReconstructionError;
 use types::ExecPayload;
 use types::{
-    BeaconBlockRef, BeaconState, BeaconStateError, BlindedPayload, ChainSpec, CloneConfig, Epoch,
-    EthSpec, ExecutionBlockHash, Hash256, InconsistentFork, PublicKey, PublicKeyBytes,
-    RelativeEpoch, SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
+    AsSignedBlock, BeaconBlockRef, BeaconState, BeaconStateError, BlindedPayload, ChainSpec,
+    CloneConfig, Epoch, EthSpec, ExecutionBlockHash, Hash256, InconsistentFork, PublicKey,
+    PublicKeyBytes, RelativeEpoch, SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
 };
 
 pub const POS_PANDA_BANNER: &str = r#"
@@ -644,7 +644,7 @@ pub struct GossipVerifiedBlock<T: BeaconChainTypes, B: TryIntoAvailableBlock<T>>
     consensus_context: ConsensusContext<T::EthSpec>,
 }
 
-impl_as_signed_block!(B: TryIntoAvailableBlock<T,>, GossipVerifiedBlock<T, B>, B, .block);
+impl_as_signed_block!(T::EthSpec, T: BeaconChainTypes, B: TryIntoAvailableBlock<T,>,, GossipVerifiedBlock<T, B>, B, .block);
 
 impl<T: BeaconChainTypes> IntoWrappedAvailabilityPendingBlock<T>
     for GossipVerifiedBlock<T, AvailabilityPendingBlock<T::EthSpec>>
@@ -696,7 +696,7 @@ pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: TryIntoAvailableBlock<
     consensus_context: ConsensusContext<T::EthSpec>,
 }
 
-impl_as_signed_block!(B: TryIntoAvailableBlock<T,>, SignatureVerifiedBlock<T, B>, B, .block);
+impl_as_signed_block!(T::EthSpec, T: BeaconChainTypes, B: TryIntoAvailableBlock<T,>,, SignatureVerifiedBlock<T, B>, B, .block);
 
 impl<T: BeaconChainTypes> IntoWrappedAvailabilityPendingBlock<T>
     for SignatureVerifiedBlock<T, AvailabilityPendingBlock<T::EthSpec>>
@@ -766,7 +766,7 @@ pub struct ExecutionPendingBlock<T: BeaconChainTypes, B: TryIntoAvailableBlock<T
     pub payload_verification_handle: PayloadVerificationHandle<T::EthSpec>,
 }
 
-impl_as_signed_block!(B: TryIntoAvailableBlock<T,>, ExecutionPendingBlock<T, B>, B, .block);
+impl_as_signed_block!(T::EthSpec, T: BeaconChainTypes, B: TryIntoAvailableBlock<T,>,, ExecutionPendingBlock<T, B>, B, .block);
 
 impl<T: BeaconChainTypes> IntoWrappedAvailabilityPendingBlock<T>
     for ExecutionPendingBlock<T, AvailabilityPendingBlock<T::EthSpec>>

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -627,7 +627,7 @@ pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: IntoAvailabilityPendin
     consensus_context: ConsensusContext<T::EthSpec>,
 }
 
-impl_as_signed_block!(SignatureVerifiedBlock<T, B>, .block, T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T,>);
+impl_as_signed_block!(SignatureVerifiedBlock<T, B>, .block, B: IntoAvailabilityPendingBlock<T,>);
 
 /// Used to await the result of executing payload with a remote EE.
 type PayloadVerificationHandle<E> =
@@ -1651,7 +1651,7 @@ fn check_block_against_finalized_slot<T: BeaconChainTypes>(
 /// Taking a lock on the `chain.canonical_head.fork_choice` might cause a deadlock here.
 pub fn check_block_is_finalized_descendant<
     T: BeaconChainTypes,
-    B: Into<BlockWrapper<T::EthSpec>> + AsSignedBlock<T::EthSpec>,
+    B: Into<BlockWrapper<T::EthSpec>> + AsSignedBlock<T>,
 >(
     chain: &BeaconChain<T>,
     fork_choice: &BeaconForkChoice<T>,
@@ -1767,10 +1767,7 @@ fn verify_parent_block_is_known<T: BeaconChainTypes>(
 /// Returns `Err(BlockError::ParentUnknown)` if the parent is not found, or if an error occurs
 /// whilst attempting the operation.
 #[allow(clippy::type_complexity)]
-fn load_parent<
-    T: BeaconChainTypes,
-    B: Into<BlockWrapper<T::EthSpec>> + AsSignedBlock<T::EthSpec>,
->(
+fn load_parent<T: BeaconChainTypes, B: Into<BlockWrapper<T::EthSpec>> + AsSignedBlock<T>>(
     block_root: Hash256,
     block: B,
     chain: &BeaconChain<T>,

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -541,7 +541,11 @@ fn process_block_slash_info<T: BeaconChainTypes>(
 ///
 /// The given `chain_segment` must contain only blocks from the same epoch, otherwise an error
 /// will be returned.
-pub fn signature_verify_chain_segment<T: BeaconChainTypes, B: AsSignedBlock<T::EthSpec>>(
+pub fn signature_verify_chain_segment<
+    T: BeaconChainTypes,
+    A: AsSignedBlock<T::EthSpec> + Send + Sync,
+    B: IntoAvailabilityPendingBlock<T::EthSpec, A>,
+>(
     mut chain_segment: Vec<(Hash256, BlockWrapper<T::EthSpec>)>,
     chain: &BeaconChain<T>,
 ) -> Result<Vec<SignatureVerifiedBlock<T, B>>, BlockError<T::EthSpec>> {
@@ -695,7 +699,12 @@ pub trait IntoExecutionPendingBlock<T: BeaconChainTypes, B: AsSignedBlock<T::Eth
     fn block(&self) -> &SignedBeaconBlock<T::EthSpec>;
 }
 
-impl<T: BeaconChainTypes, B: AsSignedBlock<T::EthSpec>> GossipVerifiedBlock<T, B> {
+impl<
+        T: BeaconChainTypes,
+        A: AsSignedBlock<T::EthSpec> + Send + Sync,
+        B: IntoAvailabilityPendingBlock<T::EthSpec, A>,
+    > GossipVerifiedBlock<T, A, B>
+{
     /// Instantiates `Self`, a wrapper that indicates the given `block` is safe to be re-gossiped
     /// on the p2p network.
     ///

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -290,8 +290,6 @@ pub enum BlockError<T: EthSpec> {
     /// The peer sent us an invalid block, but I'm not really sure how to score this in an
     /// "optimistic" sync world.
     ParentExecutionPayloadInvalid { parent_root: Hash256 },
-    /// Block is aready an [`ExecutedBlock`].
-    BlockIsExecutedBlock,
     /// Blob validation failed.
     BlobValidation(BlobError<T>),
     /// Making a block available failed. The [`DataAvailabilityFailure`] error contains the block
@@ -640,7 +638,6 @@ pub struct GossipVerifiedBlock<T: BeaconChainTypes, B: TryIntoAvailableBlock<T>>
     parent: Option<PreProcessingSnapshot<T::EthSpec>>,
     consensus_context: ConsensusContext<T::EthSpec>,
 }
-
 impl_as_signed_block!(T::EthSpec, T: BeaconChainTypes, B: TryIntoAvailableBlock<T,>,, GossipVerifiedBlock<T, B>, B, .block);
 
 impl<T: BeaconChainTypes> IntoWrappedAvailabilityPendingBlock<T>

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -627,7 +627,7 @@ pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: IntoAvailabilityPendin
     consensus_context: ConsensusContext<T::EthSpec>,
 }
 
-impl_as_signed_block!(SignatureVerifiedBlock<T, B>, .block, B: IntoAvailabilityPendingBlock<T,>);
+impl_as_signed_block!(B, SignatureVerifiedBlock<T, B>, .block, B: IntoAvailabilityPendingBlock<T,>);
 
 /// Used to await the result of executing payload with a remote EE.
 type PayloadVerificationHandle<E> =

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -44,8 +44,8 @@
 //!
 //! ```
 use crate::blob_verification::{
-    AsSignedBlock,  AvailabilityPendingBlock, AvailableBlock, BlobError,
-    BlockWrapper, DataAvailabilityFailure, IntoAvailabilityPendingBlock,
+    AsSignedBlock, AvailabilityPendingBlock, AvailableBlock, BlobError, BlockWrapper,
+    DataAvailabilityFailure, IntoAvailabilityPendingBlock,
 };
 use crate::eth1_finalization_cache::Eth1FinalizationData;
 use crate::execution_payload::{

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -62,7 +62,7 @@ use crate::{
     },
     metrics, BeaconChain, BeaconChainError, BeaconChainTypes,
 };
-use crate::{impl_as_signed_block, impl_as_signed_block_fn};
+use crate::{impl_as_signed_block, impl_as_signed_block_fn, impl_from_error};
 use derivative::Derivative;
 use eth2::types::EventKind;
 use execution_layer::PayloadStatus;
@@ -289,16 +289,6 @@ pub enum BlockError<T: EthSpec> {
     ParentExecutionPayloadInvalid { parent_root: Hash256 },
     /// Blob validation failed.
     BlobValidation(BlobError<T>),
-}
-
-macro_rules! impl_from_error {
-    ($(<$($generic: ident : $trait: ident,)*>)*, $from_error: ty, $to_error: ty, $to_error_variant: path) => {
-        impl$(<$($generic: $trait)*>)* From<$from_error> for $to_error {
-            fn from(e: $from_error) -> Self {
-                $to_error_variant(e)
-            }
-        }
-    };
 }
 
 impl_from_error!(<T: EthSpec,>, BlobError<T>, BlockError<T>, Self::BlobValidation);

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -45,7 +45,7 @@
 //! ```
 use crate::blob_verification::{
     validate_blob_for_gossip, AsBlock, AvailabilityPendingBlock, AvailableBlock, BlobError,
-    BlockWrapper, IntoAvailablilityPendingBlock, IntoBlockWrapper,
+    BlockWrapper, IntoAvailabilityPendingBlock, IntoBlockWrapper,
 };
 use crate::eth1_finalization_cache::Eth1FinalizationData;
 use crate::execution_payload::{

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -62,6 +62,7 @@ use crate::{
     },
     metrics, BeaconChain, BeaconChainError, BeaconChainTypes,
 };
+use crate::{impl_as_signed_block, impl_as_signed_block_fn};
 use derivative::Derivative;
 use eth2::types::EventKind;
 use execution_layer::PayloadStatus;
@@ -627,11 +628,13 @@ pub struct GossipVerifiedBlock<T: BeaconChainTypes, B: AsSignedBlock<T::EthSpec>
 /// A wrapper around a `SignedBeaconBlock` that indicates that all signatures (except the deposit
 /// signatures) have been verified.
 pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: AsSignedBlock<T::EthSpec>> {
-    pub block: B,
+    block: B,
     block_root: Hash256,
     parent: Option<PreProcessingSnapshot<T::EthSpec>>,
     consensus_context: ConsensusContext<T::EthSpec>,
 }
+
+impl_as_signed_block!(SignatureVerifiedBlock<E, A>, E: EthSpec, A: AsSignedBlock<E>, .block);
 
 /// Used to await the result of executing payload with a remote EE.
 type PayloadVerificationHandle<E> =

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -544,10 +544,7 @@ fn process_block_slash_info<T: BeaconChainTypes>(
 ///
 /// The given `chain_segment` must contain only blocks from the same epoch, otherwise an error
 /// will be returned.
-pub fn signature_verify_chain_segment<
-    T: BeaconChainTypes,
-    B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
->(
+pub fn signature_verify_chain_segment<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>>(
     mut chain_segment: Vec<(Hash256, BlockWrapper<T::EthSpec>)>,
     chain: &BeaconChain<T>,
 ) -> Result<Vec<SignatureVerifiedBlock<T, B>>, BlockError<T::EthSpec>> {
@@ -614,10 +611,7 @@ pub fn signature_verify_chain_segment<
 /// the p2p network.
 #[derive(Derivative)]
 #[derivative(Debug(bound = "T: BeaconChainTypes"))]
-pub struct GossipVerifiedBlock<
-    T: BeaconChainTypes,
-    B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-> {
+pub struct GossipVerifiedBlock<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> {
     pub block: B,
     pub block_root: Hash256,
     parent: Option<PreProcessingSnapshot<T::EthSpec>>,
@@ -626,17 +620,14 @@ pub struct GossipVerifiedBlock<
 
 /// A wrapper around a `SignedBeaconBlock` that indicates that all signatures (except the deposit
 /// signatures) have been verified.
-pub struct SignatureVerifiedBlock<
-    T: BeaconChainTypes,
-    B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-> {
+pub struct SignatureVerifiedBlock<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> {
     block: B,
     block_root: Hash256,
     parent: Option<PreProcessingSnapshot<T::EthSpec>>,
     consensus_context: ConsensusContext<T::EthSpec>,
 }
 
-impl_as_signed_block!(SignatureVerifiedBlock<T, B>, .block, T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T,> + SignedBlock<E,> + Send + Sync,);
+impl_as_signed_block!(SignatureVerifiedBlock<T, B>, .block, T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T,> + AsSignedBlock<E,> + Send + Sync);
 
 /// Used to await the result of executing payload with a remote EE.
 type PayloadVerificationHandle<E> =
@@ -654,10 +645,7 @@ type PayloadVerificationHandle<E> =
 /// Note: a `ExecutionPendingBlock` is not _forever_ valid to be imported, it may later become invalid
 /// due to finality or some other event. A `ExecutionPendingBlock` should be imported into the
 /// `BeaconChain` immediately after it is instantiated.
-pub struct ExecutionPendingBlock<
-    T: BeaconChainTypes,
-    B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-> {
+pub struct ExecutionPendingBlock<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> {
     pub block: B,
     pub block_root: Hash256,
     pub state: BeaconState<T::EthSpec>,
@@ -671,10 +659,8 @@ pub struct ExecutionPendingBlock<
 /// Implemented on types that can be converted into a `ExecutionPendingBlock`.
 ///
 /// Used to allow functions to accept blocks at various stages of verification.
-pub trait IntoExecutionPendingBlock<
-    T: BeaconChainTypes,
-    B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
->: Sized
+pub trait IntoExecutionPendingBlock<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>>:
+    Sized
 {
     fn into_execution_pending_block(
         self,
@@ -704,11 +690,7 @@ pub trait IntoExecutionPendingBlock<
     fn block(&self) -> &SignedBeaconBlock<T::EthSpec>;
 }
 
-impl<
-        T: BeaconChainTypes,
-        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-    > GossipVerifiedBlock<T, B>
-{
+impl<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> GossipVerifiedBlock<T, B> {
     /// Instantiates `Self`, a wrapper that indicates the given `block` is safe to be re-gossiped
     /// on the p2p network.
     ///
@@ -945,10 +927,8 @@ impl<
     }
 }
 
-impl<
-        T: BeaconChainTypes,
-        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-    > IntoExecutionPendingBlock<T, B> for GossipVerifiedBlock<T, B>
+impl<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> IntoExecutionPendingBlock<T, B>
+    for GossipVerifiedBlock<T, B>
 {
     /// Completes verification of the wrapped `block`.
     fn into_execution_pending_block_slashable(
@@ -971,11 +951,7 @@ impl<
     }
 }
 
-impl<
-        T: BeaconChainTypes,
-        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-    > SignatureVerifiedBlock<T, B>
-{
+impl<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> SignatureVerifiedBlock<T, B> {
     /// Instantiates `Self`, a wrapper that indicates that all signatures (except the deposit
     /// signatures) are valid  (i.e., signed by the correct public keys).
     ///
@@ -1095,10 +1071,8 @@ impl<
     }
 }
 
-impl<
-        T: BeaconChainTypes,
-        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-    > IntoExecutionPendingBlock<T, B> for SignatureVerifiedBlock<T, B>
+impl<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> IntoExecutionPendingBlock<T, B>
+    for SignatureVerifiedBlock<T, B>
 {
     /// Completes verification of the wrapped `block`.
     fn into_execution_pending_block_slashable(
@@ -1131,10 +1105,8 @@ impl<
     }
 }
 
-impl<
-        T: BeaconChainTypes,
-        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-    > IntoExecutionPendingBlock<T, B> for Arc<SignedBeaconBlock<T::EthSpec>>
+impl<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> IntoExecutionPendingBlock<T, B>
+    for Arc<SignedBeaconBlock<T::EthSpec>>
 {
     /// Verifies the `SignedBeaconBlock` by first transforming it into a `SignatureVerifiedBlock`
     /// and then using that implementation of `IntoExecutionPendingBlock` to complete verification.
@@ -1157,10 +1129,8 @@ impl<
     }
 }
 
-impl<
-        T: BeaconChainTypes,
-        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-    > IntoExecutionPendingBlock<T, B> for AvailabilityPendingBlock<T::EthSpec>
+impl<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> IntoExecutionPendingBlock<T, B>
+    for AvailabilityPendingBlock<T::EthSpec>
 {
     /// Verifies the `SignedBeaconBlock` by first transforming it into a `SignatureVerifiedBlock`
     /// and then using that implementation of `IntoExecutionPendingBlock` to complete verification.
@@ -1183,10 +1153,8 @@ impl<
     }
 }
 
-impl<
-        T: BeaconChainTypes,
-        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-    > IntoExecutionPendingBlock<T, B> for AvailableBlock<T::EthSpec>
+impl<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> IntoExecutionPendingBlock<T, B>
+    for AvailableBlock<T::EthSpec>
 {
     /// Verifies the `SignedBeaconBlock` by first transforming it into a `SignatureVerifiedBlock`
     /// and then using that implementation of `IntoExecutionPendingBlock` to complete verification.
@@ -1209,11 +1177,7 @@ impl<
     }
 }
 
-impl<
-        T: BeaconChainTypes,
-        B: IntoAvailabilityPendingBlock<T> + AsSignedBlock<T::EthSpec> + Send + Sync,
-    > ExecutionPendingBlock<T, B>
-{
+impl<T: BeaconChainTypes, B: IntoAvailabilityPendingBlock<T>> ExecutionPendingBlock<T, B> {
     /// Instantiates `Self`, a wrapper that indicates that the given `block` is fully valid. See
     /// the struct-level documentation for more information.
     ///

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1,5 +1,5 @@
 use crate::beacon_chain::{
-    CanonicalHead, PendingAvailabilityCache, BEACON_CHAIN_DB_KEY,
+    CanonicalHead, PendingAvailabilityCache, BEACON_CHAIN_DB_KEY, DEFAULT_BLOB_CHANNEL_CAPACITY,
     DEFAULT_PENDING_AVAILABILITY_CHANNELS, ETH1_CACHE_DB_KEY, OP_POOL_DB_KEY,
 };
 use crate::blob_cache::BlobCache;
@@ -788,7 +788,8 @@ where
         let head_for_snapshot_cache = head_snapshot.clone();
         let canonical_head = CanonicalHead::new(fork_choice, Arc::new(head_snapshot));
 
-        let (rx, pending_availability_cache_tx) = mpsc::channel::<ExecutedBlock<T::EthSpec>>();
+        let (rx, pending_availability_cache_tx) =
+            mpsc::channel::<ExecutedBlock<EthSpec>>(DEFAULT_BLOB_CHANNEL_CAPACITY);
 
         let beacon_chain = BeaconChain {
             spec: self.spec,

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -932,16 +932,16 @@ where
                 loop {
                     tokio::select! {
                         executed_block = rx => {
-                            pending_blocks.push(executed_block.unwrap_or_clone());
+                            pending_blocks.push(executed_block);
                         }
-                        Some(Err(block, e)) = pending_blocks => {
+                        Some(Err(block, blobs, e)) = pending_blocks => {
                             // todo(emhane): deal with timeout error, like get on rpc...let unknown parent trigger get block if doesn't come. and remove cached senders at time bound or lru.
                         }
                         Some(Ok((available_block, executed_block))) = pending_blocks => {
                             chain.spawn_blocking_handle(
                                 move || {
                                     chain.import_block_from_pending_availability_cache(
-                                        Arc::new(executed_block)
+                                        executed_block
                                     )
                                 },
                                 "import_block_from_peding_availability_cache_handle",

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::beacon_chain::{
     AvailabilityPendingCache, CanonicalHead, BEACON_CHAIN_DB_KEY, DEFAULT_BLOB_CHANNEL_CAPACITY,
-    DEFAULT_PENDING_AVAILABILITY_CHANNELS, ETH1_CACHE_DB_KEY, OP_POOL_DB_KEY,
+    DEFAULT_PENDING_AVAILABILITY_BLOCKS, ETH1_CACHE_DB_KEY, OP_POOL_DB_KEY,
 };
 use crate::blob_cache::BlobCache;
 use crate::blob_verification::ExecutedBlock;
@@ -861,8 +861,7 @@ where
             blob_cache: BlobCache::default(),
             kzg,
             pending_availability_cache_tx,
-            pending_blocks_rx: LruCache::new(DEFAULT_PENDING_AVAILABILITY_CHANNELS),
-            pending_blobs_tx: LruCache::new(DEFAULT_PENDING_AVAILABILITY_CHANNELS),
+            pending_blocks_tx_rx: RwLock::new(HashMap::new()),
         };
 
         let head = beacon_chain.head_snapshot();

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1,5 +1,5 @@
 use crate::beacon_chain::{
-    AvailabilityPendingCache, CanonicalHead, BEACON_CHAIN_DB_KEY, DEFAULT_BLOB_CHANNEL_CAPACITY,
+    AvailabilityPendingCache, CanonicalHead, BEACON_CHAIN_DB_KEY,
     DEFAULT_PENDING_AVAILABILITY_BLOCKS, ETH1_CACHE_DB_KEY, OP_POOL_DB_KEY,
 };
 use crate::blob_cache::BlobCache;
@@ -33,6 +33,7 @@ use proto_array::ReOrgThreshold;
 use slasher::Slasher;
 use slog::{crit, error, info, Logger};
 use slot_clock::{SlotClock, TestingSlotClock};
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
@@ -789,7 +790,7 @@ where
         let canonical_head = CanonicalHead::new(fork_choice, Arc::new(head_snapshot));
 
         let (rx, pending_availability_cache_tx) =
-            mpsc::channel::<ExecutedBlock<EthSpec>>(DEFAULT_BLOB_CHANNEL_CAPACITY);
+            mpsc::channel::<ExecutedBlock<TEthSpec>>(TEthSpec::max_blobs_per_block());
 
         let beacon_chain = BeaconChain {
             spec: self.spec,
@@ -861,7 +862,9 @@ where
             blob_cache: BlobCache::default(),
             kzg,
             pending_availability_cache_tx,
-            pending_blocks_tx_rx: RwLock::new(HashMap::new()),
+            pending_blocks_tx_rx: RwLock::new(HashMap::new_with_capacity(
+                DEFAULT_PENDING_AVAILABILITY_BLOCKS,
+            )),
         };
 
         let head = beacon_chain.head_snapshot();

--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -69,7 +69,8 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
             },
         };
 
-        let (block, blobs) = block.deconstruct();
+        // todo(emhane)
+        /*let (block, blobs) = block.deconstruct();
         let item = CacheItem {
             epoch,
             committee_lengths,
@@ -81,7 +82,7 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
             proto_block,
         };
 
-        *self.item.write() = Some(item);
+        *self.item.write() = Some(item);*/
 
         Ok(())
     }

--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -1,4 +1,4 @@
-use crate::blob_verification::{AvailabilityPendingBlock, AvailableBlock};
+use crate::blob_verification::AvailableBlock;
 use crate::{
     attester_cache::{CommitteeLengths, Error},
     metrics,

--- a/beacon_node/beacon_chain/src/eth1_finalization_cache.rs
+++ b/beacon_node/beacon_chain/src/eth1_finalization_cache.rs
@@ -10,7 +10,7 @@ pub const DEFAULT_ETH1_CACHE_SIZE: usize = 5;
 
 /// These fields are named the same as the corresponding fields in the `BeaconState`
 /// as this structure stores these values from the `BeaconState` at a `Checkpoint`
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Eth1FinalizationData {
     pub eth1_data: Eth1Data,
     pub eth1_deposit_index: u64,

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -13,7 +13,7 @@ pub fn validate_blobs_sidecar<T: EthSpec>(
     slot: Slot,
     beacon_block_root: Hash256,
     expected_kzg_commitments: &[KzgCommitment],
-    blob_sidecars: Vec<BlobSidecar<T>>,
+    blob_sidecars: VariableList<BlobSidecar<T>, T::MaxBlobsPerBlock>,
 ) -> Result<bool, KzgError> {
     if slot != blob_sidecars.beacon_block_slot
         || beacon_block_root != blob_sidecars.beacon_block_root

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -1,5 +1,6 @@
 use kzg::{Error as KzgError, Kzg, BYTES_PER_BLOB};
-use types::{Blob, BlobsSidecar, EthSpec, Hash256, KzgCommitment, KzgProof, Slot};
+use ssz_types::VariableList;
+use types::{Blob, EthSpec, Hash256, KzgCommitment, KzgProof, Slot};
 
 use crate::blob_verification::AsBlobSidecar;
 
@@ -10,7 +11,7 @@ fn ssz_blob_to_crypto_blob<T: EthSpec>(blob: Blob<T>) -> kzg::Blob {
     arr.into()
 }
 
-pub fn validate_blob_sidecars<T: EthSpec, Bs: AsBlobSidecar<E>>(
+pub fn validate_blob_sidecars<T: EthSpec, Bs: AsBlobSidecar<T>>(
     kzg: &Kzg,
     slot: Slot,
     beacon_block_root: Hash256,
@@ -28,7 +29,7 @@ pub fn validate_blob_sidecars<T: EthSpec, Bs: AsBlobSidecar<E>>(
         }
     }
 
-    blobs.sort_by(|a, b| a.blob_index().partial_cmp(b.blob_index()).unwrap());
+    blob_sidecars.sort_by(|a, b| a.blob_index().partial_cmp(b.blob_index()).unwrap());
     let blobs = blob_sidecars
         .into_iter()
         .map(|blob| ssz_blob_to_crypto_blob::<T>(blob.blob.clone())) // TODO(pawan): avoid this clone

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -13,16 +13,16 @@ pub fn validate_blobs_sidecar<T: EthSpec>(
     slot: Slot,
     beacon_block_root: Hash256,
     expected_kzg_commitments: &[KzgCommitment],
-    blobs_sidecar: &BlobsSidecar<T>,
+    blob_sidecars: Vec<BlobSidecar<T>>,
 ) -> Result<bool, KzgError> {
-    if slot != blobs_sidecar.beacon_block_slot
-        || beacon_block_root != blobs_sidecar.beacon_block_root
-        || blobs_sidecar.blobs.len() != expected_kzg_commitments.len()
+    if slot != blob_sidecars.beacon_block_slot
+        || beacon_block_root != blob_sidecars.beacon_block_root
+        || blob_sidecars.blobs.len() != expected_kzg_commitments.len()
     {
         return Ok(false);
     }
 
-    let blobs = blobs_sidecar
+    let blobs = blob_sidecars
         .blobs
         .into_iter()
         .map(|blob| ssz_blob_to_crypto_blob::<T>(blob.clone())) // TODO(pawan): avoid this clone
@@ -31,7 +31,7 @@ pub fn validate_blobs_sidecar<T: EthSpec>(
     kzg.verify_aggregate_kzg_proof(
         &blobs,
         expected_kzg_commitments,
-        blobs_sidecar.kzg_aggregated_proof,
+        blob_sidecars.kzg_aggregated_proof,
     )
 }
 

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -1,8 +1,7 @@
-use kzg::{Error as KzgError, Kzg, BYTES_PER_BLOB};
+use kzg::{Error as KzgError, Kzg, KzgProof, BYTES_PER_BLOB};
 use ssz_types::VariableList;
-use types::{Blob, EthSpec, Hash256, KzgCommitment, KzgProof, Slot};
-
-use crate::blob_verification::AsBlobSidecar;
+use std::sync::Arc;
+use types::{Blob, BlobSidecar, EthSpec, Hash256, KzgCommitment, Slot};
 
 fn ssz_blob_to_crypto_blob<T: EthSpec>(blob: Blob<T>) -> kzg::Blob {
     let blob_vec: Vec<u8> = blob.into();
@@ -11,40 +10,36 @@ fn ssz_blob_to_crypto_blob<T: EthSpec>(blob: Blob<T>) -> kzg::Blob {
     arr.into()
 }
 
-pub fn validate_blob_sidecars<T: EthSpec, Bs: AsBlobSidecar<T>>(
+pub fn validate_blob_sidecars<T: EthSpec>(
     kzg: Kzg,
     slot: Slot,
     beacon_block_root: Hash256,
     expected_kzg_commitments: &[KzgCommitment],
-    blob_sidecars: VariableList<Bs, T::MaxBlobsPerBlock>,
+    blob_sidecars: VariableList<Arc<BlobSidecar<T>>, T::MaxBlobsPerBlock>,
 ) -> Result<bool, KzgError> {
     if blob_sidecars.len() != expected_kzg_commitments.len() {
         return Ok(false);
     }
     for blob_sidecar in blob_sidecars.iter() {
-        if slot != blob_sidecar.beacon_block_slot()
-            || beacon_block_root != blob_sidecar.beacon_block_root()
+        if slot != blob_sidecar.beacon_block_slot
+            || beacon_block_root != blob_sidecar.beacon_block_root
         {
             return Ok(false);
         }
     }
 
-    blob_sidecars.sort_by(|a, b| a.blob_index().partial_cmp(&b.blob_index()).unwrap());
-    let (blobs, kzg_aggregate_proofs) = blob_sidecars
+    blob_sidecars.sort_by(|a, b| a.blob_index.partial_cmp(&b.blob_index).unwrap());
+    let (blobs, kzg_aggregate_proofs): (Vec<_>, Vec<_>) = blob_sidecars
         .into_iter()
         .map(|blob| {
             (
-                ssz_blob_to_crypto_blob::<T>(blob.blob().clone()),
-                blob.kzg_aggregate_proof,
+                ssz_blob_to_crypto_blob::<T>(blob.blob.clone()),
+                blob.kzg_aggregated_proof,
             )
-        }) // TODO(pawan): avoid this clone
-        .collect::<Vec<_>>();
-
-    kzg.verify_aggregate_kzg_proof(
-        &blobs,
-        expected_kzg_commitments,
-        blob_sidecars.kzg_aggregated_proof,
-    )
+        }) // TODO(pawa(n): avoid this clone
+        .unzip();
+    Ok(true)
+    //kzg.verify_aggregate_kzg_proof(&blobs, expected_kzg_commitments, kzg_aggregate_proofs)
 }
 
 pub fn compute_aggregate_kzg_proof<T: EthSpec>(

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -15,7 +15,7 @@ pub fn validate_blob_sidecars<T: EthSpec>(
     slot: Slot,
     beacon_block_root: Hash256,
     expected_kzg_commitments: &[KzgCommitment],
-    blob_sidecars: VariableList<Arc<BlobSidecar<T>>, T::MaxBlobsPerBlock>,
+    mut blob_sidecars: VariableList<Arc<BlobSidecar<T>>, T::MaxBlobsPerBlock>,
 ) -> Result<bool, KzgError> {
     if blob_sidecars.len() != expected_kzg_commitments.len() {
         return Ok(false);

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -8,7 +8,7 @@ fn ssz_blob_to_crypto_blob<T: EthSpec>(blob: Blob<T>) -> kzg::Blob {
     arr.into()
 }
 
-pub fn validate_blobs_sidecar<T: EthSpec>(
+pub fn validate_blob_sidecars<T: EthSpec>(
     kzg: &Kzg,
     slot: Slot,
     beacon_block_root: Hash256,
@@ -17,15 +17,15 @@ pub fn validate_blobs_sidecar<T: EthSpec>(
 ) -> Result<bool, KzgError> {
     if slot != blob_sidecars.beacon_block_slot
         || beacon_block_root != blob_sidecars.beacon_block_root
-        || blob_sidecars.blobs.len() != expected_kzg_commitments.len()
+        || blob_sidecars.len() != expected_kzg_commitments.len()
     {
         return Ok(false);
     }
 
+    blobs.sort_by(|a, b| a.index().partial_cmp(b.index()).unwrap());
     let blobs = blob_sidecars
-        .blobs
         .into_iter()
-        .map(|blob| ssz_blob_to_crypto_blob::<T>(blob.clone())) // TODO(pawan): avoid this clone
+        .map(|blob| ssz_blob_to_crypto_blob::<T>(blob.blob.clone())) // TODO(pawan): avoid this clone
         .collect::<Vec<_>>();
 
     kzg.verify_aggregate_kzg_proof(

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -551,7 +551,7 @@ where
 
         BeaconChainHarness {
             spec: chain.spec.clone(),
-            chain: Arc::new(chain),
+            chain,
             validator_keypairs,
             withdrawal_keypairs: self.withdrawal_keypairs,
             shutdown_receiver: Arc::new(Mutex::new(shutdown_receiver)),

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -864,7 +864,7 @@ async fn block_gossip_verification() {
     assert!(
         matches!(
             unwrap_err(harness.chain.verify_block_for_gossip(Arc::new(SignedBeaconBlock::from_block(block, signature))).await),
-            BlockError::ParentUnknown(block)
+            BlockError::ParentUnknown(block.into())
             if block.parent_root() == parent_root
         ),
         "should not import a block for an unknown parent"

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -35,7 +35,7 @@ time = "0.3.5"
 directory = {path = "../../common/directory"}
 http_api = { path = "../http_api" }
 http_metrics = { path = "../http_metrics" }
-slasher = { path = "../../slasher" }
+slasher = { path = "../../slasher", default-features = false }
 slasher_service = { path = "../../slasher/service" }
 monitoring_api = {path = "../../common/monitoring_api"}
 execution_layer = { path = "../execution_layer" }

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -853,7 +853,7 @@ where
             .build()
             .map_err(|e| format!("Failed to build beacon chain: {}", e))?;
 
-        self.beacon_chain = Some(Arc::new(chain));
+        self.beacon_chain = Some(chain);
         self.beacon_chain_builder = None;
 
         // a beacon chain requires a timer

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -1,5 +1,5 @@
 use crate::metrics;
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper, IntoAvailableBlock};
+use beacon_chain::blob_verification::{AsBlock, BlockWrapper, IntoAvailablilityPendingBlock};
 use beacon_chain::validator_monitor::{get_block_delay_ms, timestamp_now};
 use beacon_chain::NotifyExecutionLayer;
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockError, CountUnrealized};

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -1,5 +1,5 @@
 use crate::metrics;
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper, IntoAvailabilityPendingBlock};
+use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper, IntoAvailabilityPendingBlock};
 use beacon_chain::validator_monitor::{get_block_delay_ms, timestamp_now};
 use beacon_chain::NotifyExecutionLayer;
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockError, CountUnrealized};

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -1,5 +1,5 @@
 use crate::metrics;
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper, IntoAvailablilityPendingBlock};
+use beacon_chain::blob_verification::{AsBlock, BlockWrapper, IntoAvailabilityPendingBlock};
 use beacon_chain::validator_monitor::{get_block_delay_ms, timestamp_now};
 use beacon_chain::NotifyExecutionLayer;
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockError, CountUnrealized};

--- a/beacon_node/lighthouse_network/src/types/pubsub.rs
+++ b/beacon_node/lighthouse_network/src/types/pubsub.rs
@@ -12,14 +12,17 @@ use types::{
     Attestation, AttesterSlashing, EthSpec, ForkContext, ForkName, LightClientFinalityUpdate,
     LightClientOptimisticUpdate, ProposerSlashing, SignedAggregateAndProof, SignedBeaconBlock,
     SignedBeaconBlockAltair, SignedBeaconBlockAndBlobsSidecar, SignedBeaconBlockBase,
-    SignedBeaconBlockCapella, SignedBeaconBlockMerge, SignedBlsToExecutionChange,
-    SignedContributionAndProof, SignedVoluntaryExit, SubnetId, SyncCommitteeMessage, SyncSubnetId,
+    SignedBeaconBlockCapella, SignedBeaconBlockMerge, SignedBlobSidecar,
+    SignedBlsToExecutionChange, SignedContributionAndProof, SignedVoluntaryExit, SubnetId,
+    SyncCommitteeMessage, SyncSubnetId,
 };
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum PubsubMessage<T: EthSpec> {
     /// Gossipsub message providing notification of a new block.
     BeaconBlock(Arc<SignedBeaconBlock<T>>),
+    /// Gossipsub message providing notification of a new SignedBlobSidecar.
+    //BlobSidecar(Arc<SignedBlobSidecar<T>>),
     /// Gossipsub message providing notification of a new SignedBeaconBlock coupled with a blobs sidecar.
     BeaconBlockAndBlobsSidecars(SignedBeaconBlockAndBlobsSidecar<T>),
     /// Gossipsub message providing notification of a Aggregate attestation and associated proof.

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -40,7 +40,7 @@
 
 use crate::sync::manager::BlockProcessType;
 use crate::{metrics, service::NetworkMessage, sync::SyncMessage};
-use beacon_chain::blob_verification::BlockWrapper;
+use beacon_chain::blob_verification::SomeAvailabilityBlock;
 use beacon_chain::parking_lot::Mutex;
 use beacon_chain::{BeaconChain, BeaconChainTypes, GossipVerifiedBlock, NotifyExecutionLayer};
 use derivative::Derivative;
@@ -605,7 +605,7 @@ impl<T: BeaconChainTypes> WorkEvent<T> {
     /// sent to the other side of `result_tx`.
     pub fn rpc_beacon_block(
         block_root: Hash256,
-        block: BlockWrapper<T::EthSpec>,
+        block: SomeAvailabilityBlock<T::EthSpec>,
         seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) -> Self {
@@ -624,7 +624,7 @@ impl<T: BeaconChainTypes> WorkEvent<T> {
     /// Create a new work event to import `blocks` as a beacon chain segment.
     pub fn chain_segment(
         process_id: ChainSegmentProcessId,
-        blocks: Vec<BlockWrapper<T::EthSpec>>,
+        blocks: Vec<SomeAvailabilityBlock<T::EthSpec>>,
     ) -> Self {
         Self {
             drop_during_sync: false,
@@ -866,7 +866,7 @@ pub enum Work<T: BeaconChainTypes> {
     },
     DelayedImportBlock {
         peer_id: PeerId,
-        block: Box<GossipVerifiedBlock<T>>,
+        block: Box<GossipVerifiedBlock<T, SomeAvailabilityBlock<T::EthSpec>>>,
         seen_timestamp: Duration,
     },
     GossipVoluntaryExit {
@@ -911,14 +911,14 @@ pub enum Work<T: BeaconChainTypes> {
     },
     RpcBlock {
         block_root: Hash256,
-        block: BlockWrapper<T::EthSpec>,
+        block: SomeAvailabilityBlock<T::EthSpec>,
         seen_timestamp: Duration,
         process_type: BlockProcessType,
         should_process: bool,
     },
     ChainSegment {
         process_id: ChainSegmentProcessId,
-        blocks: Vec<BlockWrapper<T::EthSpec>>,
+        blocks: Vec<SomeAvailabilityBlock<T::EthSpec>>,
     },
     Status {
         peer_id: PeerId,

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -13,7 +13,7 @@
 use super::MAX_SCHEDULED_WORK_QUEUE_LEN;
 use crate::metrics;
 use crate::sync::manager::BlockProcessType;
-use beacon_chain::blob_verification::{AsSignedBlock, SomeAvailabilityBlock};
+use beacon_chain::blob_verification::SomeAvailabilityBlock;
 use beacon_chain::{BeaconChainTypes, GossipVerifiedBlock, MAXIMUM_GOSSIP_CLOCK_DISPARITY};
 use fnv::FnvHashMap;
 use futures::task::Poll;
@@ -31,7 +31,8 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::time::error::Error as TimeError;
 use tokio_util::time::delay_queue::{DelayQueue, Key as DelayKey};
 use types::{
-    Attestation, EthSpec, Hash256, LightClientOptimisticUpdate, SignedAggregateAndProof, SubnetId,
+    AsSignedBlock, Attestation, EthSpec, Hash256, LightClientOptimisticUpdate,
+    SignedAggregateAndProof, SubnetId,
 };
 
 const TASK_NAME: &str = "beacon_processor_reprocess_queue";

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -13,7 +13,7 @@
 use super::MAX_SCHEDULED_WORK_QUEUE_LEN;
 use crate::metrics;
 use crate::sync::manager::BlockProcessType;
-use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, SomeAvailabilityBlock};
 use beacon_chain::{BeaconChainTypes, GossipVerifiedBlock, MAXIMUM_GOSSIP_CLOCK_DISPARITY};
 use fnv::FnvHashMap;
 use futures::task::Poll;
@@ -127,7 +127,7 @@ pub struct QueuedLightClientUpdate<T: EthSpec> {
 /// A block that arrived early and has been queued for later import.
 pub struct QueuedGossipBlock<T: BeaconChainTypes> {
     pub peer_id: PeerId,
-    pub block: Box<GossipVerifiedBlock<T>>,
+    pub block: Box<GossipVerifiedBlock<T, SomeAvailabilityBlock<T::EthSpec>>>,
     pub seen_timestamp: Duration,
 }
 
@@ -135,7 +135,7 @@ pub struct QueuedGossipBlock<T: BeaconChainTypes> {
 /// It is queued for later import.
 pub struct QueuedRpcBlock<T: EthSpec> {
     pub block_root: Hash256,
-    pub block: BlockWrapper<T>,
+    pub block: SomeAvailabilityBlock<T>,
     pub process_type: BlockProcessType,
     pub seen_timestamp: Duration,
     /// Indicates if the beacon chain should process this block or not.

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -355,7 +355,7 @@ impl<T: BeaconChainTypes> ReprocessQueue<T> {
             // Some block has been indicated as "early" and should be processed when the
             // appropriate slot arrives.
             InboundEvent::Msg(EarlyBlock(early_block)) => {
-                let block_slot = <SomeAvailabilityBlock<<T as BeaconChainTypes>::EthSpec> as AsSignedBlock<T>>::slot(&early_block.block.block);
+                let block_slot = early_block.block.block.slot();
                 let block_root = early_block.block.block_root;
 
                 // Don't add the same block to the queue twice. This prevents DoS attacks.

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -355,7 +355,7 @@ impl<T: BeaconChainTypes> ReprocessQueue<T> {
             // Some block has been indicated as "early" and should be processed when the
             // appropriate slot arrives.
             InboundEvent::Msg(EarlyBlock(early_block)) => {
-                let block_slot = early_block.block.block.slot();
+                let block_slot = <SomeAvailabilityBlock<<T as BeaconChainTypes>::EthSpec> as AsSignedBlock<T>>::slot(&early_block.block.block);
                 let block_root = early_block.block.block_root;
 
                 // Don't add the same block to the queue twice. This prevents DoS attacks.

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -13,7 +13,7 @@
 use super::MAX_SCHEDULED_WORK_QUEUE_LEN;
 use crate::metrics;
 use crate::sync::manager::BlockProcessType;
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
 use beacon_chain::{BeaconChainTypes, GossipVerifiedBlock, MAXIMUM_GOSSIP_CLOCK_DISPARITY};
 use fnv::FnvHashMap;
 use futures::task::Poll;

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -669,8 +669,11 @@ impl<T: BeaconChainTypes> Worker<T> {
         };
         let (oneshot_tx, oneshot_rx) = mpsc::oneshot::<Result<(), BlobError>>();
         let gossip_verified_blob = GossipVerifiedBlob(Arc::new(blob));
-        tx.send((gossip_verified_blob, tx_oneshot))?;
-        rx_oneshot.await?;
+        tx.send((gossip_verified_blob, tx_oneshot))
+            .map_err(|e| DataAvailabilityFailure::Block(None, blobs, e));
+        rx_oneshot
+            .await
+            .map_err(|e| DataAvailabilityFailure::Block(None, blobs, e))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -656,7 +656,7 @@ impl<T: BeaconChainTypes> Worker<T> {
         blob: Arc<SignedBlobSidecar<T::EthSpec>>,
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
         seen_duration: Duration,
-    ) -> Result<(), BlobError<T::EthSpec>> {
+    ) -> Result<(), BlobError<T>> {
         // todo(emhane): verify signature
         let channels = self.chain.pending_blocks_tx_rx.write();
         let tx = match channels.entry(block_root) {
@@ -698,7 +698,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             Entry::Vacant(e) => {
                 let (tx, rx) = mpsc::channel::<(
                     Arc<SignedBlobSidecar<T::EthSpec>>,
-                    Option<oneshot::Sender<Result<(), BlobError<T::EthSpec>>>>,
+                    Option<oneshot::Sender<Result<(), BlobError<T>>>>,
                 )>(T::EthSpec::max_blobs_per_block());
                 channels.insert(block_root, (tx.clone(), Some(rx)));
                 tx

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -656,14 +656,14 @@ impl<T: BeaconChainTypes> Worker<T> {
         seen_duration: Duration,
     ) -> Result<(), BlobError> {
         // todo(emhane): verify signature
-        let (tx, rx) = match self.chain.pending_blobs_tx_rx.get(block_root) {
-            Some(channel) => (channel.0, channel.1),
+        let tx = match self.chain.pending_blobs_tx.get(block_root) {
+            Some(tx) => tx,
             None => {
                 let (tx, rx) = mpsc::channel::<(
                     GossipVerifiedBlob<T::EthSpec>,
                     oneshot::Sender<Result<(), BlobError>>,
                 )>(DEFAULT_BLOB_CHANNEL_CAPACITY);
-                self.chain.pending_blocks_tx_rx.put(block_root, rx);
+                self.chain.pending_blocks_rx.put(block_root, rx);
                 (tx, rx)
             }
         };
@@ -671,9 +671,14 @@ impl<T: BeaconChainTypes> Worker<T> {
         let gossip_verified_blob = GossipVerifiedBlob(Arc::new(blob));
         tx.send((gossip_verified_blob, tx_oneshot))
             .map_err(|e| DataAvailabilityFailure::Block(None, blobs, e));
-        rx_oneshot
-            .await
-            .map_err(|e| DataAvailabilityFailure::Block(None, blobs, e))
+        match rx_oneshot.await {
+            Err(BlobError::BlobAlreadyExistsAtIndex(naughty_blob)) => {
+                // todo(emhane): https://github.com/ethereum/consensus-specs/issues/3261
+                Ok(())
+            }
+            Err(e) => Err(DataAvailabilityFailure::Block(None, blobs, e)),
+            Ok(()) => Ok(()),
+        }
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -655,19 +655,19 @@ impl<T: BeaconChainTypes> Worker<T> {
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
         seen_duration: Duration,
     ) -> Result<GossipVerifiedBlob<T>, BlobError> {
-        let Some(entry) = self.chain.pending_blobs.get(blob.beacon_block_root()) else {
-            return None
-        };
         // todo(emhane): A blob at this index already exits, don't propagate blob, as according to
-        // spec (if kzg-verified or also not kzg-verified?)
-        if entry
-            .blobs
-            .iter()
-            .find(|cache_blob| cached_blob.blob_index() == blob.blob_index())
-        {
-            return None;
-        }
-        Ok(GossipVerifiedBlob(blob))
+        // spec (if kzg-verified or also not kzg-verified? only the former seems safe, hence todo
+        // links to singly kzg-verifying)
+        /*if let Some(entry) = self.chain.pending_blobs.get(blob.beacon_block_root()) {
+             if !entry
+             .blobs
+             .iter()
+             .find(|cache_blob| cached_blob.blob_index() == blob.blob_index())
+        {*/
+        return Ok(GossipVerifiedBlob(blob));
+        //}
+        //}
+        //return Err("a blob for this block at this index exists");
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -1058,7 +1058,7 @@ impl<T: BeaconChainTypes> Worker<T> {
         self,
         peer_id: PeerId,
         verified_block: GossipVerifiedBlock<T, B>,
-        reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
+        reprocess_tx: tokio::sync::mpsc::Sender<ReprocessQueueMessage<T>>,
         // This value is not used presently, but it might come in handy for debugging.
         _seen_duration: Duration,
     ) {

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -674,13 +674,14 @@ impl<T: BeaconChainTypes> Worker<T> {
                                     seen_blobs.push(blob);
                                 }
                                 Ok(None) => {
-                                    // and put the blobs back when done
+                                    // index filtering
                                     if seen_blobs.iter().find(|existing_blob| {
                                         existing_blob.blob_index()
                                             == gossip_verified_blob.blob_index()
                                     }) {
                                         // todo(emhane): https://github.com/ethereum/consensus-specs/issues/3261
                                     }
+                                    // and put the blobs back when done
                                     for blob in seen_blobs {
                                         tx.send((blob, None));
                                     }
@@ -699,7 +700,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     Arc<SignedBlobSidecar<T::EthSpec>>,
                     Option<oneshot::Sender<Result<(), BlobError<T::EthSpec>>>>,
                 )>(T::EthSpec::max_blobs_per_block());
-                *channels.insert(block_root, (tx.clone(), Some(rx)));
+                channels.insert(block_root, (tx.clone(), Some(rx)));
                 tx
             }
         };

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -662,10 +662,10 @@ impl<T: BeaconChainTypes> Worker<T> {
         let tx = match channels.entry(block_root) {
             Entry::Occupied(mut e) => {
                 match *e.get_mut() {
-                    // if the block didn't come yet to pick up its receiver, borrow it and do the
-                    // index filtering here, while locking the `pending_blocks_tx_rx` to make sure
-                    // no other blob workers do the same. if the block comes before all its blobs,
-                    // this will not have to be done.
+                    // A fallback solution to filtering, if the block didn't come yet to pick up
+                    // its receiver, borrow it and do the index filtering here, while locking the
+                    // `pending_blocks_tx_rx` to make sure no other blob workers do the same. if
+                    // the block comes before all its blobs, this will not have to be done.
                     (tx, Some(rx)) => {
                         let mut seen_blobs = Vec::with_capacity(T::EthSpec::max_blobs_per_block());
                         loop {

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -10,7 +10,7 @@ use beacon_chain::{
     sync_committee_verification::{self, Error as SyncCommitteeError},
     validator_monitor::get_block_delay_ms,
     BeaconChainError, BeaconChainTypes, BlockError, CountUnrealized, ForkChoiceError,
-    GossipVerifiedBlock, NotifyExecutionLayer,
+    GossipVerifiedBlock, NotifyExecutionLayer, DEFAULT_BLOB_CHANNEL_CAPACITY,
 };
 use futures::channel::mpsc;
 use lighthouse_network::{Client, MessageAcceptance, MessageId, PeerAction, PeerId, ReportSource};
@@ -697,10 +697,8 @@ impl<T: BeaconChainTypes> Worker<T> {
             let tx = match self.chain.pending_blobs_tx.get(block_root) {
                 Some(tx) => tx,
                 None => {
-                    // Channel with double capacity to T::EthSpec::MaxBlobsPerBlock, incase block
-                    // comes late and duplicate blobs arrive for each index.
                     let (tx, rx) = mpsc::channel::<GossipVerifiedBlob<T::EthSpec>>(
-                        T::EthSpec::MaxBlobsPerBlock * 2,
+                        DEFUALT_BLOB_CHANNEL_CAPACITY,
                     );
                     self.chain.pending_blocks_rx.put(block_root, rx);
                     tx

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -673,6 +673,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             Some((_, Some(_))) | None => None,
         };
         drop(channels);
+
         let tx = match sender_to_block {
             Some(tx) => tx,
             None => {

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -752,6 +752,8 @@ impl<T: BeaconChainTypes> Worker<T> {
                     "block_root" => block_root,
                     "error" => e
             );
+
+            // todo(emhane) : propagate blob
         }
     }
 

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -676,7 +676,7 @@ impl<T: BeaconChainTypes> Worker<T> {
         let tx = match sender_to_block {
             Some(tx) => tx,
             None => {
-                let channels = self.chain.pending_blocks_tx_rx.read();
+                let channels = self.chain.pending_blocks_tx_rx.write();
                 let tx = match channels.entry(block_root) {
                     Entry::Occupied(mut e) => {
                         match *e.get_mut() {

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -7,9 +7,7 @@ use crate::beacon_processor::DuplicateCache;
 use crate::metrics;
 use crate::sync::manager::{BlockProcessType, SyncMessage};
 use crate::sync::{BatchProcessResult, ChainId};
-use beacon_chain::blob_verification::{
-    AsSignedBlock, SomeAvailabilityBlock, TryIntoAvailableBlock,
-};
+use beacon_chain::blob_verification::{SomeAvailabilityBlock, TryIntoAvailableBlock};
 use beacon_chain::CountUnrealized;
 use beacon_chain::{
     BeaconChainError, BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError,
@@ -19,7 +17,7 @@ use lighthouse_network::PeerAction;
 use slog::{debug, error, info, warn};
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use types::{Epoch, Hash256, SignedBeaconBlock};
+use types::{AsSignedBlock, Epoch, Hash256, SignedBeaconBlock};
 
 /// Id associated to a batch processing request, either a sync batch or a parent lookup.
 #[derive(Clone, Debug, PartialEq)]

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -432,6 +432,7 @@ impl<T: BeaconChainTypes> Worker<T> {
     fn handle_failed_chain_segment(&self, error: BlockError<T>) -> Result<(), ChainSegmentFailed> {
         match error {
             BlockError::ParentUnknown(block) => {
+                let block = block.0;
                 // blocks should be sequential and all parents should exist
                 Err(ChainSegmentFailed {
                     message: format!("Block has an unknown parent: {}", block.parent_root()),

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -7,7 +7,7 @@ use crate::beacon_processor::DuplicateCache;
 use crate::metrics;
 use crate::sync::manager::{BlockProcessType, SyncMessage};
 use crate::sync::{BatchProcessResult, ChainId};
-use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper, IntoAvailabilityPendingBlock};
+use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper, TryIntoAvailableBlock};
 use beacon_chain::CountUnrealized;
 use beacon_chain::{
     BeaconChainError, BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError,
@@ -429,10 +429,7 @@ impl<T: BeaconChainTypes> Worker<T> {
     }
 
     /// Helper function to handle a `BlockError` from `process_chain_segment`
-    fn handle_failed_chain_segment(
-        &self,
-        error: BlockError<T::EthSpec>,
-    ) -> Result<(), ChainSegmentFailed> {
+    fn handle_failed_chain_segment(&self, error: BlockError<T>) -> Result<(), ChainSegmentFailed> {
         match error {
             BlockError::ParentUnknown(block) => {
                 // blocks should be sequential and all parents should exist

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -7,7 +7,7 @@ use crate::beacon_processor::DuplicateCache;
 use crate::metrics;
 use crate::sync::manager::{BlockProcessType, SyncMessage};
 use crate::sync::{BatchProcessResult, ChainId};
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper, IntoAvailableBlock};
+use beacon_chain::blob_verification::{AsBlock, BlockWrapper, IntoAvailablilityPendingBlock};
 use beacon_chain::CountUnrealized;
 use beacon_chain::{
     BeaconChainError, BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError,

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -7,7 +7,7 @@ use crate::beacon_processor::DuplicateCache;
 use crate::metrics;
 use crate::sync::manager::{BlockProcessType, SyncMessage};
 use crate::sync::{BatchProcessResult, ChainId};
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper, IntoAvailabilityPendingBlock};
+use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper, IntoAvailabilityPendingBlock};
 use beacon_chain::CountUnrealized;
 use beacon_chain::{
     BeaconChainError, BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError,

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -276,13 +276,13 @@ impl<T: BeaconChainTypes> Worker<T> {
     }
 
     /// Helper function to process blocks batches which only consumes the chain and blocks to process.
-    async fn process_blocks<'a>(
+    async fn process_blocks<'a, B: TryIntoAvailableBlock<T>>(
         &self,
-        downloaded_blocks: impl Iterator<Item = &'a BlockWrapper<T::EthSpec>>,
+        downloaded_blocks: impl Iterator<Item = &'a B>,
         count_unrealized: CountUnrealized,
         notify_execution_layer: NotifyExecutionLayer,
     ) -> (usize, Result<(), ChainSegmentFailed>) {
-        let blocks: Vec<_> = downloaded_blocks.cloned().collect();
+        let blocks: Vec<B> = downloaded_blocks.cloned().collect();
         match self
             .chain
             .process_chain_segment(blocks, count_unrealized, notify_execution_layer)

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -7,7 +7,7 @@ use crate::beacon_processor::DuplicateCache;
 use crate::metrics;
 use crate::sync::manager::{BlockProcessType, SyncMessage};
 use crate::sync::{BatchProcessResult, ChainId};
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper, IntoAvailablilityPendingBlock};
+use beacon_chain::blob_verification::{AsBlock, BlockWrapper, IntoAvailabilityPendingBlock};
 use beacon_chain::CountUnrealized;
 use beacon_chain::{
     BeaconChainError, BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError,

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -7,7 +7,7 @@ use crate::beacon_processor::DuplicateCache;
 use crate::metrics;
 use crate::sync::manager::{BlockProcessType, SyncMessage};
 use crate::sync::{BatchProcessResult, ChainId};
-use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper, TryIntoAvailableBlock};
+use beacon_chain::blob_verification::{AsSignedBlock, SomeAvailabilityBlock, TryIntoAvailableBlock};
 use beacon_chain::CountUnrealized;
 use beacon_chain::{
     BeaconChainError, BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError,
@@ -44,7 +44,7 @@ impl<T: BeaconChainTypes> Worker<T> {
     pub async fn process_rpc_block(
         self,
         block_root: Hash256,
-        block: BlockWrapper<T::EthSpec>,
+        block: SomeAvailabilityBlock<T::EthSpec>,
         seen_timestamp: Duration,
         process_type: BlockProcessType,
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
@@ -145,7 +145,7 @@ impl<T: BeaconChainTypes> Worker<T> {
     pub async fn process_chain_segment(
         &self,
         sync_type: ChainSegmentProcessId,
-        downloaded_blocks: Vec<BlockWrapper<T::EthSpec>>,
+        downloaded_blocks: Vec<SomeAvailabilityBlock<T::EthSpec>>,
         notify_execution_layer: NotifyExecutionLayer,
     ) {
         let result = match sync_type {
@@ -429,7 +429,7 @@ impl<T: BeaconChainTypes> Worker<T> {
     }
 
     /// Helper function to handle a `BlockError` from `process_chain_segment`
-    fn handle_failed_chain_segment(&self, error: BlockError<T>) -> Result<(), ChainSegmentFailed> {
+    fn handle_failed_chain_segment(&self, error: BlockError<T::EthSpec>) -> Result<(), ChainSegmentFailed> {
         match error {
             BlockError::ParentUnknown(block) => {
                 let block = block.0;

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -366,7 +366,7 @@ impl<T: BeaconChainTypes> Processor<T> {
         peer_client: Client,
         block_and_blobs: SignedBeaconBlockAndBlobsSidecar<T::EthSpec>,
     ) {
-        self.send_beacon_processor_work(BeaconWorkEvent::gossip_block_and_blobs_sidecar(
+        self.send_beacon_processor_work(BeaconWorkEvent::gossip_blob_sidecar(
             message_id,
             peer_id,
             peer_client,

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -51,35 +51,33 @@ impl TestBeaconChain {
 
         let test_runtime = TestRuntime::default();
 
-        let chain = Arc::new(
-            BeaconChainBuilder::new(MainnetEthSpec)
-                .logger(log.clone())
-                .custom_spec(spec.clone())
-                .store(Arc::new(store))
-                .task_executor(test_runtime.task_executor.clone())
-                .genesis_state(
-                    interop_genesis_state::<MainnetEthSpec>(
-                        &keypairs,
-                        0,
-                        Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
-                        None,
-                        &spec,
-                    )
-                    .expect("should generate interop state"),
+        let chain = BeaconChainBuilder::new(MainnetEthSpec)
+            .logger(log.clone())
+            .custom_spec(spec.clone())
+            .store(Arc::new(store))
+            .task_executor(test_runtime.task_executor.clone())
+            .genesis_state(
+                interop_genesis_state::<MainnetEthSpec>(
+                    &keypairs,
+                    0,
+                    Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
+                    None,
+                    &spec,
                 )
-                .expect("should build state using recent genesis")
-                .dummy_eth1_backend()
-                .expect("should build dummy backend")
-                .slot_clock(SystemTimeSlotClock::new(
-                    Slot::new(0),
-                    Duration::from_secs(recent_genesis_time()),
-                    Duration::from_millis(SLOT_DURATION_MILLIS),
-                ))
-                .shutdown_sender(shutdown_tx)
-                .monitor_validators(true, vec![], DEFAULT_INDIVIDUAL_TRACKING_THRESHOLD, log)
-                .build()
-                .expect("should build"),
-        );
+                .expect("should generate interop state"),
+            )
+            .expect("should build state using recent genesis")
+            .dummy_eth1_backend()
+            .expect("should build dummy backend")
+            .slot_clock(SystemTimeSlotClock::new(
+                Slot::new(0),
+                Duration::from_secs(recent_genesis_time()),
+                Duration::from_millis(SLOT_DURATION_MILLIS),
+            ))
+            .shutdown_sender(shutdown_tx)
+            .monitor_validators(true, vec![], DEFAULT_INDIVIDUAL_TRACKING_THRESHOLD, log)
+            .build()
+            .expect("should build");
         Self {
             chain,
             _test_runtime: test_runtime,

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -14,7 +14,7 @@ use crate::sync::network_context::SyncNetworkContext;
 use crate::sync::range_sync::{
     BatchConfig, BatchId, BatchInfo, BatchOperationOutcome, BatchProcessingResult, BatchState,
 };
-use beacon_chain::blob_verification::BlockWrapper;
+use beacon_chain::blob_verification::SomeAvailabilityBlock;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use lighthouse_network::types::{BackFillState, NetworkGlobals};
 use lighthouse_network::{PeerAction, PeerId};
@@ -55,7 +55,7 @@ impl BatchConfig for BackFillBatchConfig {
     fn max_batch_processing_attempts() -> u8 {
         MAX_BATCH_PROCESSING_ATTEMPTS
     }
-    fn batch_attempt_hash<T: EthSpec>(blocks: &[BlockWrapper<T>]) -> u64 {
+    fn batch_attempt_hash<T: EthSpec>(blocks: &[SomeAvailabilityBlock<T>]) -> u64 {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
         let mut hasher = DefaultHasher::new();
@@ -391,7 +391,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         batch_id: BatchId,
         peer_id: &PeerId,
         request_id: Id,
-        beacon_block: Option<BlockWrapper<T::EthSpec>>,
+        beacon_block: Option<SomeAvailabilityBlock<T::EthSpec>>,
     ) -> Result<ProcessResult, BackFillError> {
         // check if we have this batch
         let batch = match self.batches.get_mut(&batch_id) {

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -479,6 +479,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                         error!(self.log, "Beacon chain error processing single block"; "block_root" => %root, "error" => ?e);
                     }
                     BlockError::ParentUnknown(block) => {
+                        let block = block.0;
                         self.search_parent(root, block, peer_id, cx);
                     }
                     ref e @ BlockError::ExecutionPayloadError(ref epe) if !epe.penalize_peer() => {
@@ -557,6 +558,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
         match result {
             BlockProcessResult::Err(BlockError::ParentUnknown(block)) => {
+                let block = block.0;
                 // need to keep looking for parents
                 // add the block back to the queue and continue the search
                 parent_lookup.add_block(block);

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::time::Duration;
 
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
 use beacon_chain::{BeaconChainTypes, BlockError};
 use fnv::FnvHashMap;
 use lighthouse_network::rpc::{RPCError, RPCResponseErrorCode};

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -33,8 +33,6 @@ mod single_block_lookup;
 #[cfg(test)]
 mod tests;
 
-pub type RootBlockTuple<T> = (Hash256, SomeAvailabilityBlock<T>);
-
 const FAILED_CHAINS_CACHE_EXPIRY_SECONDS: u64 = 60;
 const SINGLE_BLOCK_LOOKUP_MAX_ATTEMPTS: u8 = 3;
 
@@ -479,7 +477,6 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                         error!(self.log, "Beacon chain error processing single block"; "block_root" => %root, "error" => ?e);
                     }
                     BlockError::ParentUnknown(block) => {
-                        let block = block.0;
                         self.search_parent(root, block, peer_id, cx);
                     }
                     ref e @ BlockError::ExecutionPayloadError(ref epe) if !epe.penalize_peer() => {
@@ -558,7 +555,6 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
         match result {
             BlockProcessResult::Err(BlockError::ParentUnknown(block)) => {
-                let block = block.0;
                 // need to keep looking for parents
                 // add the block back to the queue and continue the search
                 parent_lookup.add_block(block);

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::time::Duration;
 
-use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, SomeAvailabilityBlock};
 use beacon_chain::{BeaconChainTypes, BlockError};
 use fnv::FnvHashMap;
 use lighthouse_network::rpc::{RPCError, RPCResponseErrorCode};
@@ -33,7 +33,7 @@ mod single_block_lookup;
 #[cfg(test)]
 mod tests;
 
-pub type RootBlockTuple<T> = (Hash256, BlockWrapper<T>);
+pub type RootBlockTuple<T> = (Hash256, SomeAvailabilityBlock<T>);
 
 const FAILED_CHAINS_CACHE_EXPIRY_SECONDS: u64 = 60;
 const SINGLE_BLOCK_LOOKUP_MAX_ATTEMPTS: u8 = 3;
@@ -137,7 +137,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     pub fn search_parent(
         &mut self,
         block_root: Hash256,
-        block: BlockWrapper<T::EthSpec>,
+        block: SomeAvailabilityBlock<T::EthSpec>,
         peer_id: PeerId,
         cx: &mut SyncNetworkContext<T>,
     ) {
@@ -179,7 +179,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         id: Id,
         peer_id: PeerId,
-        block: Option<BlockWrapper<T::EthSpec>>,
+        block: Option<SomeAvailabilityBlock<T::EthSpec>>,
         seen_timestamp: Duration,
         cx: &mut SyncNetworkContext<T>,
     ) {
@@ -244,7 +244,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         id: Id,
         peer_id: PeerId,
-        block: Option<BlockWrapper<T::EthSpec>>,
+        block: Option<SomeAvailabilityBlock<T::EthSpec>>,
         seen_timestamp: Duration,
         cx: &mut SyncNetworkContext<T>,
     ) {
@@ -686,7 +686,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     fn send_block_for_processing(
         &mut self,
         block_root: Hash256,
-        block: BlockWrapper<T::EthSpec>,
+        block: SomeAvailabilityBlock<T::EthSpec>,
         duration: Duration,
         process_type: BlockProcessType,
         cx: &mut SyncNetworkContext<T>,

--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -1,5 +1,5 @@
 use super::RootBlockTuple;
-use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, SomeAvailabilityBlock};
 use beacon_chain::BeaconChainTypes;
 use lighthouse_network::PeerId;
 use store::Hash256;
@@ -60,7 +60,11 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
             .any(|(root, _d_block)| root == block_root)
     }
 
-    pub fn new(block_root: Hash256, block: BlockWrapper<T::EthSpec>, peer_id: PeerId) -> Self {
+    pub fn new(
+        block_root: Hash256,
+        block: SomeAvailabilityBlock<T::EthSpec>,
+        peer_id: PeerId,
+    ) -> Self {
         let current_parent_request = SingleBlockRequest::new(block.parent_root(), peer_id);
 
         Self {
@@ -99,7 +103,7 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
         self.current_parent_request.check_peer_disconnected(peer_id)
     }
 
-    pub fn add_block(&mut self, block: BlockWrapper<T::EthSpec>) {
+    pub fn add_block(&mut self, block: SomeAvailabilityBlock<T::EthSpec>) {
         let next_parent = block.parent_root();
         let current_root = self.current_parent_request.hash;
         self.downloaded_blocks.push((current_root, block));
@@ -118,7 +122,7 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
         self,
     ) -> (
         Hash256,
-        Vec<BlockWrapper<T::EthSpec>>,
+        Vec<SomeAvailabilityBlock<T::EthSpec>>,
         Vec<Hash256>,
         SingleBlockRequest<PARENT_FAIL_TOLERANCE>,
     ) {
@@ -157,7 +161,7 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
     /// the processing result of the block.
     pub fn verify_block(
         &mut self,
-        block: Option<BlockWrapper<T::EthSpec>>,
+        block: Option<SomeAvailabilityBlock<T::EthSpec>>,
         failed_chains: &mut lru_cache::LRUTimeCache<Hash256>,
     ) -> Result<Option<RootBlockTuple<T::EthSpec>>, VerifyError> {
         let root_and_block = self.current_parent_request.verify_block(block)?;

--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -1,5 +1,5 @@
 use super::RootBlockTuple;
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
 use beacon_chain::BeaconChainTypes;
 use lighthouse_network::PeerId;
 use store::Hash256;

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -1,5 +1,5 @@
 use super::RootBlockTuple;
-use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, SomeAvailabilityBlock};
 use beacon_chain::get_block_root;
 use lighthouse_network::{rpc::BlocksByRootRequest, PeerId};
 use rand::seq::IteratorRandom;
@@ -104,7 +104,7 @@ impl<const MAX_ATTEMPTS: u8> SingleBlockRequest<MAX_ATTEMPTS> {
     /// Returns the block for processing if the response is what we expected.
     pub fn verify_block<T: EthSpec>(
         &mut self,
-        block: Option<BlockWrapper<T>>,
+        block: Option<SomeAvailabilityBlock<T>>,
     ) -> Result<Option<RootBlockTuple<T>>, VerifyError> {
         match self.state {
             State::AwaitingDownload => {

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -1,5 +1,5 @@
 use super::RootBlockTuple;
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
 use beacon_chain::get_block_root;
 use lighthouse_network::{rpc::BlocksByRootRequest, PeerId};
 use rand::seq::IteratorRandom;

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -651,7 +651,11 @@ fn test_same_chain_race_condition() {
             // one block was removed
             bl.parent_block_processed(chain_hash, BlockError::BlockIsAlreadyKnown.into(), &mut cx)
         } else {
-            bl.parent_block_processed(chain_hash, BlockError::ParentUnknown(block).into(), &mut cx)
+            bl.parent_block_processed(
+                chain_hash,
+                BlockError::ParentUnknown(block.into()).into(),
+                &mut cx,
+            )
         }
         parent_lookups_consistency(&bl)
     }

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -1,4 +1,4 @@
-use beacon_chain::blob_verification::BlockWrapper;
+use beacon_chain::blob_verification::SomeAvailabilityBlock;
 use std::{collections::VecDeque, sync::Arc};
 
 use types::{BlobsSidecar, EthSpec, SignedBeaconBlock};
@@ -30,7 +30,7 @@ impl<T: EthSpec> BlocksAndBlobsRequestInfo<T> {
         }
     }
 
-    pub fn into_responses(self) -> Result<Vec<BlockWrapper<T>>, &'static str> {
+    pub fn into_responses(self) -> Result<Vec<SomeAvailabilityBlock<T>>, &'static str> {
         let BlocksAndBlobsRequestInfo {
             accumulated_blocks,
             mut accumulated_sidecars,
@@ -48,9 +48,9 @@ impl<T: EthSpec> BlocksAndBlobsRequestInfo<T> {
                     .unwrap_or(false)
                 {
                     let blobs_sidecar = accumulated_sidecars.pop_front();
-                    BlockWrapper::new(beacon_block, blobs_sidecar)
+                    SomeAvailabilityBlock::new(beacon_block, blobs_sidecar)
                 } else {
-                    BlockWrapper::new(beacon_block, None)
+                    SomeAvailabilityBlock::new(beacon_block, None)
                 }
             })
             .collect::<Vec<_>>();

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -570,11 +570,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 // If we are not synced or within SLOT_IMPORT_TOLERANCE of the block, ignore
                 if !self.network_globals.sync_state.read().is_synced() {
                     let head_slot = self.chain.canonical_head.cached_head().head_slot();
-                    let unknown_block_slot = <SomeAvailabilityBlock<
-                        <T as BeaconChainTypes>::EthSpec,
-                    > as AsSignedBlock<T>>::slot(
-                        &block
-                    );
+                    let unknown_block_slot = block.slot();
 
                     // if the block is far in the future, ignore it. If its within the slot tolerance of
                     // our current head, regardless of the syncing state, fetch it.

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -570,7 +570,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 // If we are not synced or within SLOT_IMPORT_TOLERANCE of the block, ignore
                 if !self.network_globals.sync_state.read().is_synced() {
                     let head_slot = self.chain.canonical_head.cached_head().head_slot();
-                    let unknown_block_slot = block.slot();
+                    let unknown_block_slot = <SomeAvailabilityBlock<
+                        <T as BeaconChainTypes>::EthSpec,
+                    > as AsSignedBlock<T>>::slot(
+                        &block
+                    );
 
                     // if the block is far in the future, ignore it. If its within the slot tolerance of
                     // our current head, regardless of the syncing state, fetch it.

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -42,7 +42,7 @@ use crate::beacon_processor::{ChainSegmentProcessId, WorkEvent as BeaconWorkEven
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
 use crate::sync::range_sync::ByRangeRequestType;
-use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, SomeAvailabilityBlock};
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockError, EngineState};
 use futures::StreamExt;
 use lighthouse_network::rpc::methods::MAX_REQUEST_BLOCKS;
@@ -119,7 +119,7 @@ pub enum SyncMessage<T: EthSpec> {
     },
 
     /// A block with an unknown parent has been received.
-    UnknownBlock(PeerId, BlockWrapper<T>, Hash256),
+    UnknownBlock(PeerId, SomeAvailabilityBlock<T>, Hash256),
 
     /// A peer has sent an object that references a block that is unknown. This triggers the
     /// manager to attempt to find the block matching the unknown hash.

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -42,7 +42,7 @@ use crate::beacon_processor::{ChainSegmentProcessId, WorkEvent as BeaconWorkEven
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
 use crate::sync::range_sync::ByRangeRequestType;
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockError, EngineState};
 use futures::StreamExt;
 use lighthouse_network::rpc::methods::MAX_REQUEST_BLOCKS;

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -8,7 +8,7 @@ use crate::beacon_processor::WorkEvent;
 use crate::service::{NetworkMessage, RequestId};
 use crate::status::ToStatusMessage;
 use crate::sync::block_lookups::ForceBlockRequest;
-use beacon_chain::blob_verification::BlockWrapper;
+use beacon_chain::blob_verification::SomeAvailabilityBlock;
 use beacon_chain::{BeaconChain, BeaconChainTypes, EngineState};
 use fnv::FnvHashMap;
 use lighthouse_network::rpc::methods::BlobsByRangeRequest;
@@ -293,7 +293,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     ) -> Option<(
         ChainId,
         BatchId,
-        Result<Vec<BlockWrapper<T::EthSpec>>, &'static str>,
+        Result<Vec<SomeAvailabilityBlock<T::EthSpec>>, &'static str>,
     )> {
         match self.range_blocks_and_blobs_requests.entry(request_id) {
             Entry::Occupied(mut entry) => {
@@ -362,7 +362,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         &mut self,
         request_id: Id,
         block_or_blob: BlockOrBlobs<T::EthSpec>,
-    ) -> Option<(BatchId, Result<Vec<BlockWrapper<T::EthSpec>>, &'static str>)> {
+    ) -> Option<(
+        BatchId,
+        Result<Vec<SomeAvailabilityBlock<T::EthSpec>>, &'static str>,
+    )> {
         match self.backfill_blocks_and_blobs_requests.entry(request_id) {
             Entry::Occupied(mut entry) => {
                 let (_, info) = entry.get_mut();

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -1,5 +1,5 @@
 use crate::sync::manager::Id;
-use beacon_chain::blob_verification::{AsBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
 use lighthouse_network::rpc::methods::BlocksByRangeRequest;
 use lighthouse_network::PeerId;
 use std::collections::HashSet;

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -1,5 +1,5 @@
 use crate::sync::manager::Id;
-use beacon_chain::blob_verification::{AsSignedBlock, BlockWrapper};
+use beacon_chain::blob_verification::{AsSignedBlock, SomeAvailabilityBlock};
 use lighthouse_network::rpc::methods::BlocksByRangeRequest;
 use lighthouse_network::PeerId;
 use std::collections::HashSet;
@@ -56,7 +56,7 @@ pub trait BatchConfig {
     /// Note that simpler hashing functions considered in the past (hash of first block, hash of last
     /// block, number of received blocks) are not good enough to differentiate attempts. For this
     /// reason, we hash the complete set of blocks both in RangeSync and BackFillSync.
-    fn batch_attempt_hash<T: EthSpec>(blocks: &[BlockWrapper<T>]) -> u64;
+    fn batch_attempt_hash<T: EthSpec>(blocks: &[SomeAvailabilityBlock<T>]) -> u64;
 }
 
 pub struct RangeSyncBatchConfig {}
@@ -68,7 +68,7 @@ impl BatchConfig for RangeSyncBatchConfig {
     fn max_batch_processing_attempts() -> u8 {
         MAX_BATCH_PROCESSING_ATTEMPTS
     }
-    fn batch_attempt_hash<T: EthSpec>(blocks: &[BlockWrapper<T>]) -> u64 {
+    fn batch_attempt_hash<T: EthSpec>(blocks: &[SomeAvailabilityBlock<T>]) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         blocks.hash(&mut hasher);
         hasher.finish()
@@ -116,9 +116,9 @@ pub enum BatchState<T: EthSpec> {
     /// The batch has failed either downloading or processing, but can be requested again.
     AwaitingDownload,
     /// The batch is being downloaded.
-    Downloading(PeerId, Vec<BlockWrapper<T>>, Id),
+    Downloading(PeerId, Vec<SomeAvailabilityBlock<T>>, Id),
     /// The batch has been completely downloaded and is ready for processing.
-    AwaitingProcessing(PeerId, Vec<BlockWrapper<T>>),
+    AwaitingProcessing(PeerId, Vec<SomeAvailabilityBlock<T>>),
     /// The batch is being processed.
     Processing(Attempt),
     /// The batch was successfully processed and is waiting to be validated.
@@ -251,7 +251,7 @@ impl<T: EthSpec, B: BatchConfig> BatchInfo<T, B> {
     }
 
     /// Adds a block to a downloading batch.
-    pub fn add_block(&mut self, block: BlockWrapper<T>) -> Result<(), WrongState> {
+    pub fn add_block(&mut self, block: SomeAvailabilityBlock<T>) -> Result<(), WrongState> {
         match self.state.poison() {
             BatchState::Downloading(peer, mut blocks, req_id) => {
                 blocks.push(block);
@@ -383,7 +383,7 @@ impl<T: EthSpec, B: BatchConfig> BatchInfo<T, B> {
         }
     }
 
-    pub fn start_processing(&mut self) -> Result<Vec<BlockWrapper<T>>, WrongState> {
+    pub fn start_processing(&mut self) -> Result<Vec<SomeAvailabilityBlock<T>>, WrongState> {
         match self.state.poison() {
             BatchState::AwaitingProcessing(peer, blocks) => {
                 self.state = BatchState::Processing(Attempt::new::<B, T>(peer, &blocks));
@@ -481,7 +481,10 @@ pub struct Attempt {
 }
 
 impl Attempt {
-    fn new<B: BatchConfig, T: EthSpec>(peer_id: PeerId, blocks: &[BlockWrapper<T>]) -> Self {
+    fn new<B: BatchConfig, T: EthSpec>(
+        peer_id: PeerId,
+        blocks: &[SomeAvailabilityBlock<T>],
+    ) -> Self {
         let hash = B::batch_attempt_hash(blocks);
         Attempt { peer_id, hash }
     }

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -1,12 +1,12 @@
 use crate::sync::manager::Id;
-use beacon_chain::blob_verification::{AsSignedBlock, SomeAvailabilityBlock};
+use beacon_chain::blob_verification::SomeAvailabilityBlock;
 use lighthouse_network::rpc::methods::BlocksByRangeRequest;
 use lighthouse_network::PeerId;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::ops::Sub;
 use strum::Display;
-use types::{Epoch, EthSpec, Slot};
+use types::{AsSignedBlock, Epoch, EthSpec, Slot};
 
 /// The number of times to retry a batch before it is considered failed.
 const MAX_BATCH_DOWNLOAD_ATTEMPTS: u8 = 5;

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -3,7 +3,7 @@ use crate::beacon_processor::{ChainSegmentProcessId, WorkEvent as BeaconWorkEven
 use crate::sync::{
     manager::Id, network_context::SyncNetworkContext, BatchOperationOutcome, BatchProcessResult,
 };
-use beacon_chain::blob_verification::BlockWrapper;
+use beacon_chain::blob_verification::SomeAvailabilityBlock;
 use beacon_chain::{BeaconChainTypes, CountUnrealized};
 use fnv::FnvHashMap;
 use lighthouse_network::{PeerAction, PeerId};
@@ -231,7 +231,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         batch_id: BatchId,
         peer_id: &PeerId,
         request_id: Id,
-        beacon_block: Option<BlockWrapper<T::EthSpec>>,
+        beacon_block: Option<SomeAvailabilityBlock<T::EthSpec>>,
     ) -> ProcessingResult {
         // check if we have this batch
         let batch = match self.batches.get_mut(&batch_id) {

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -47,7 +47,7 @@ use crate::status::ToStatusMessage;
 use crate::sync::manager::Id;
 use crate::sync::network_context::SyncNetworkContext;
 use crate::sync::BatchProcessResult;
-use beacon_chain::blob_verification::BlockWrapper;
+use beacon_chain::blob_verification::SomeAvailabilityBlock;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use lighthouse_network::rpc::GoodbyeReason;
 use lighthouse_network::PeerId;
@@ -203,7 +203,7 @@ where
         chain_id: ChainId,
         batch_id: BatchId,
         request_id: Id,
-        beacon_block: Option<BlockWrapper<T::EthSpec>>,
+        beacon_block: Option<SomeAvailabilityBlock<T::EthSpec>>,
     ) {
         // check if this chunk removes the chain
         match self.chains.call_by_id(chain_id, |chain| {

--- a/book/src/installation-source.md
+++ b/book/src/installation-source.md
@@ -133,6 +133,15 @@ Commonly used features include:
 * `slasher-lmdb`: support for the LMDB slasher backend.
 * `jemalloc`: use [`jemalloc`][jemalloc] to allocate memory. Enabled by default on Linux and macOS.
   Not supported on Windows.
+* `spec-minimal`: support for the minimal preset (useful for testing).
+
+Default features (e.g. `slasher-mdbx`) may be opted out of using the `--no-default-features`
+argument for `cargo`, which can plumbed in via the `CARGO_INSTALL_EXTRA_FLAGS` environment variable.
+E.g.
+
+```
+CARGO_INSTALL_EXTRA_FLAGS="--no-default-features" make
+```
 
 [jemalloc]: https://jemalloc.net/
 

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -367,6 +367,7 @@ mod tests {
             boot_enr,
             genesis_state_bytes: genesis_state.as_ref().map(Encode::as_ssz_bytes),
             config,
+            kzg_trusted_setup: None,
         };
 
         testnet

--- a/common/slot_clock/src/lib.rs
+++ b/common/slot_clock/src/lib.rs
@@ -5,12 +5,12 @@ mod manual_slot_clock;
 mod metrics;
 mod system_time_slot_clock;
 
-use std::time::Duration;
-
 pub use crate::manual_slot_clock::ManualSlotClock;
 pub use crate::manual_slot_clock::ManualSlotClock as TestingSlotClock;
 pub use crate::system_time_slot_clock::SystemTimeSlotClock;
 pub use metrics::scrape_for_metrics;
+use std::fmt::Debug;
+use std::time::Duration;
 use types::consts::merge::INTERVALS_PER_SLOT;
 pub use types::Slot;
 

--- a/common/task_executor/src/lib.rs
+++ b/common/task_executor/src/lib.rs
@@ -268,6 +268,18 @@ impl TaskExecutor {
         }
     }
 
+    pub fn spawn_handle_mock<R: Send + 'static>(
+        &self,
+        result: R,
+    ) -> Option<tokio::task::JoinHandle<Option<R>>> {
+        if let Some(handle) = self.handle() {
+            Some(handle.spawn(async { Some(result) }))
+        } else {
+            debug!(self.log, "Couldn't spawn task. Runtime shutting down");
+            None
+        }
+    }
+
     /// Spawn a blocking task on a dedicated tokio thread pool wrapped in an exit future returning
     /// a join handle to the future.
     /// If the runtime doesn't exist, this will return None.

--- a/consensus/state_processing/src/consensus_context.rs
+++ b/consensus/state_processing/src/consensus_context.rs
@@ -7,7 +7,7 @@ use types::{
     ChainSpec, Epoch, EthSpec, Hash256, IndexedAttestation, SignedBeaconBlock, Slot,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConsensusContext<T: EthSpec> {
     /// Slot to act as an identifier/safeguard
     slot: Slot,

--- a/consensus/types/src/beacon_chain_types.rs
+++ b/consensus/types/src/beacon_chain_types.rs
@@ -1,0 +1,7 @@
+pub trait BeaconChainTypes: Send + Sync + 'static {
+    type HotStore: store::ItemStore<Self::EthSpec>;
+    type ColdStore: store::ItemStore<Self::EthSpec>;
+    type SlotClock: slot_clock::SlotClock;
+    type Eth1Chain: Eth1ChainBackend<Self::EthSpec>;
+    type EthSpec: types::EthSpec;
+}

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -6,7 +6,6 @@ use kzg::KzgProof;
 use serde_derive::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
-use ssz_types::VariableList;
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
@@ -57,7 +56,6 @@ impl<T: EthSpec> BlobSidecar<T> {
     Encode,
     Decode,
     TreeHash,
-    Default,
     TestRandom,
     Derivative,
     arbitrary::Arbitrary,
@@ -66,7 +64,7 @@ impl<T: EthSpec> BlobSidecar<T> {
 #[arbitrary(bound = "T: EthSpec")]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
 pub struct SignedBlobSidecar<T: EthSpec> {
-    pub message: BlobsSidecar<T>,
+    pub message: BlobSidecar<T>,
     pub signature: Signature,
 }
 

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -69,10 +69,6 @@ pub struct SignedBlobSidecar<T: EthSpec> {
 }
 
 impl<T: EthSpec> SignedBlobSidecar<T> {
-    pub fn empty() -> Self {
-        Self::default()
-    }
-
     #[allow(clippy::integer_arithmetic)]
     pub fn max_size() -> usize {
         <SignedBlobSidecar<T> as Encode>::ssz_fixed_len()

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -31,7 +31,7 @@ pub struct BlobSidecar<T: EthSpec> {
     pub proposer_index: u64,
     pub block_parent_root: Hash256,
     pub blob_index: u64,
-    pub blobs: Blob<T>,
+    pub blob: Blob<T>,
     pub kzg_aggregated_proof: KzgProof,
 }
 
@@ -72,5 +72,9 @@ impl<T: EthSpec> SignedBlobSidecar<T> {
     #[allow(clippy::integer_arithmetic)]
     pub fn max_size() -> usize {
         <SignedBlobSidecar<T> as Encode>::ssz_fixed_len()
+    }
+
+    pub fn message(&self) -> &BlobSidecar<T> {
+        &self.message
     }
 }

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -1,5 +1,5 @@
 use crate::test_utils::TestRandom;
-use crate::{Blob, BlobsSidecar, EthSpec, Hash256, SignedRoot, Slot};
+use crate::{Blob, EthSpec, Hash256, SignedRoot, Slot};
 use bls::Signature;
 use derivative::Derivative;
 use kzg::KzgProof;

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -1,5 +1,7 @@
+use crate::beacon_chain::blob_verification::AsSignedBlobSidecar;
+use crate::impl_as_signed_blob_sidecar;
 use crate::test_utils::TestRandom;
-use crate::{Blob, EthSpec, Hash256, SignedRoot, Slot};
+use crate::{BeaconBlockHeader, Blob, EthSpec, Hash256, SignedBeaconBlockHeader, SignedRoot, Slot};
 use bls::Signature;
 use derivative::Derivative;
 use kzg::KzgProof;
@@ -28,8 +30,10 @@ use tree_hash_derive::TreeHash;
 pub struct BlobSidecar<T: EthSpec> {
     pub beacon_block_root: Hash256,
     pub beacon_block_slot: Slot,
+    #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub proposer_index: u64,
     pub block_parent_root: Hash256,
+    #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub blob_index: u64,
     pub blob: Blob<T>,
     pub kzg_aggregated_proof: KzgProof,
@@ -46,6 +50,18 @@ impl<T: EthSpec> BlobSidecar<T> {
     pub fn max_size() -> usize {
         <BlobSidecar<T> as Encode>::ssz_fixed_len()
     }
+
+    // todo(emhane)
+    /*/// Returns a full `BeaconBlockHeader` of this blob.
+    pub fn blob_sidecar_header(&self) -> BeaconBlockHeader {
+        BeaconBlockHeader {
+            slot: self.beacon_block_slot,
+            proposer_index: self.proposer_index,
+            parent_root: self.block_parent_root,
+            //state_root: self.state_root(),
+            body_root: self.beacon_block_root,
+        }
+    }*/
 }
 
 #[derive(
@@ -73,8 +89,29 @@ impl<T: EthSpec> SignedBlobSidecar<T> {
     pub fn max_size() -> usize {
         <SignedBlobSidecar<T> as Encode>::ssz_fixed_len()
     }
+}
 
-    pub fn message(&self) -> &BlobSidecar<T> {
+impl<T: EthSpec> AsSignedBlobSidecar<T> for SignedBlobSidecar<T> {
+    #[allow(clippy::integer_arithmetic)]
+    impl_as_signed_blob_sidecar!(beacon_block_root, Hash256);
+    impl_as_signed_blob_sidecar!(beacon_block_slot, Slot);
+    impl_as_signed_blob_sidecar!(proposer_index, u64);
+    impl_as_signed_blob_sidecar!(block_parent_root, Hash256);
+    impl_as_signed_blob_sidecar!(blob_index, u64);
+    impl_as_signed_blob_sidecar!(kzg_aggregated_proof, KzgProof);
+    fn message(&self) -> &BlobSidecar<T> {
         &self.message
     }
+    // todo(emhane)
+    /*/// Produce a signed beacon block header corresponding to this blob.
+    pub fn signed_block_header(&self) -> SignedBeaconBlockHeader {
+        SignedBeaconBlockHeader {
+            message: self.message().blob_sidecar_header(),
+            signature: self.signature.clone(),
+        }
+    }*/
+    fn as_blob(&self) -> &Blob<T> {
+        &self.message().blob
+    }
+    fn blob_cloned(&self) -> Arc<SignedBlobSidecar<T>> {}
 }

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -90,7 +90,7 @@ impl<T: EthSpec> SignedBlobSidecar<T> {
     }
 }
 
-pub trait AsSignedBlobSidecar<E: EthSpec>: Debug {
+pub trait AsSignedBlobSidecar<E: EthSpec> {
     fn beacon_block_root(&self) -> Hash256;
     fn beacon_block_slot(&self) -> Slot;
     fn proposer_index(&self) -> u64;

--- a/consensus/types/src/blobs_sidecar.rs
+++ b/consensus/types/src/blobs_sidecar.rs
@@ -1,5 +1,5 @@
 use crate::test_utils::TestRandom;
-use crate::{Blob, EthSpec, Hash256, SignedRoot, Slot};
+use crate::{Blob, EthSpec, Hash256, Slot};
 use derivative::Derivative;
 use kzg::KzgProof;
 use serde_derive::{Deserialize, Serialize};

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -121,7 +121,7 @@ pub use crate::beacon_block_body::{
 pub use crate::beacon_block_header::BeaconBlockHeader;
 pub use crate::beacon_committee::{BeaconCommittee, OwnedBeaconCommittee};
 pub use crate::beacon_state::{BeaconTreeHashCache, Error as BeaconStateError, *};
-pub use crate::blob_sidecar::{BlobSidecar, SignedBlobSidecar};
+pub use crate::blob_sidecar::{AsSignedBlobSidecar, BlobSidecar, SignedBlobSidecar};
 pub use crate::blobs_sidecar::BlobsSidecar;
 pub use crate::bls_to_execution_change::BlsToExecutionChange;
 pub use crate::chain_spec::{ChainSpec, Config, Domain};
@@ -173,9 +173,9 @@ pub use crate::selection_proof::SelectionProof;
 pub use crate::shuffling_id::AttestationShufflingId;
 pub use crate::signed_aggregate_and_proof::SignedAggregateAndProof;
 pub use crate::signed_beacon_block::{
-    SignedBeaconBlock, SignedBeaconBlockAltair, SignedBeaconBlockBase, SignedBeaconBlockCapella,
-    SignedBeaconBlockEip4844, SignedBeaconBlockHash, SignedBeaconBlockMerge,
-    SignedBlindedBeaconBlock,
+    AsSignedBlock, SignedBeaconBlock, SignedBeaconBlockAltair, SignedBeaconBlockBase,
+    SignedBeaconBlockCapella, SignedBeaconBlockEip4844, SignedBeaconBlockHash,
+    SignedBeaconBlockMerge, SignedBlindedBeaconBlock,
 };
 pub use crate::signed_beacon_block_header::SignedBeaconBlockHeader;
 pub use crate::signed_block_and_blobs::SignedBeaconBlockAndBlobsSidecar;

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -121,6 +121,7 @@ pub use crate::beacon_block_body::{
 pub use crate::beacon_block_header::BeaconBlockHeader;
 pub use crate::beacon_committee::{BeaconCommittee, OwnedBeaconCommittee};
 pub use crate::beacon_state::{BeaconTreeHashCache, Error as BeaconStateError, *};
+pub use crate::blob_sidecar::{BlobSidecar, SignedBlobSidecar};
 pub use crate::blobs_sidecar::BlobsSidecar;
 pub use crate::bls_to_execution_change::BlsToExecutionChange;
 pub use crate::chain_spec::{ChainSpec, Config, Domain};

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -527,19 +527,7 @@ impl<E: EthSpec> SignedBeaconBlock<E> {
     }
 }
 
-pub trait AsSignedBlock<T: EthSpec>: Debug {
-    fn block_root(&self) -> Hash256;
-    fn slot(&self) -> Slot;
-    fn epoch(&self) -> Epoch;
-    fn parent_root(&self) -> Hash256;
-    fn state_root(&self) -> Hash256;
-    fn signed_block_header(&self) -> SignedBeaconBlockHeader;
-    fn message(&self) -> BeaconBlockRef<T>;
-    fn as_block(&self) -> &SignedBeaconBlock<T>;
-    fn block_cloned(&self) -> Arc<SignedBeaconBlock<T>>;
-}
-
-impl<T: EthSpec> AsSignedBlock<T> for Arc<SignedBeaconBlock<T>> {
+pub trait AsSignedBlock<T: EthSpec> {
     fn block_root(&self) -> Hash256 {
         self.block_root()
     }
@@ -561,11 +549,25 @@ impl<T: EthSpec> AsSignedBlock<T> for Arc<SignedBeaconBlock<T>> {
     fn message(&self) -> BeaconBlockRef<T> {
         self.message()
     }
+    fn as_block(&self) -> &SignedBeaconBlock<T>;
+    fn block_cloned(&self) -> Arc<SignedBeaconBlock<T>>;
+}
+
+impl<T: EthSpec> AsSignedBlock<T> for Arc<SignedBeaconBlock<T>> {
     fn as_block(&self) -> &SignedBeaconBlock<T> {
         &*self
     }
     fn block_cloned(&self) -> Arc<SignedBeaconBlock<T>> {
         self.clone()
+    }
+}
+
+impl<T: EthSpec> AsSignedBlock<T> for &Arc<SignedBeaconBlock<T>> {
+    fn as_block(&self) -> &SignedBeaconBlock<T> {
+        &*self
+    }
+    fn block_cloned(&self) -> Arc<SignedBeaconBlock<T>> {
+        (*self).clone()
     }
 }
 

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -226,6 +226,11 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> SignedBeaconBlock<E, Payload> 
         }
     }
 
+    /// Convenience accessor for the block's block root.
+    pub fn block_root(&self) -> Hash256 {
+        self.message().body_root()
+    }
+
     /// Convenience accessor for the block's slot.
     pub fn slot(&self) -> Slot {
         self.message().slot()

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -3,7 +3,7 @@ use bls::Signature;
 use derivative::Derivative;
 use serde_derive::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use std::fmt;
+use std::{fmt, fmt::Debug, sync::Arc};
 use superstruct::superstruct;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
@@ -524,6 +524,48 @@ impl<E: EthSpec> From<SignedBeaconBlock<E>> for SignedBlindedBeaconBlock<E> {
 impl<E: EthSpec> SignedBeaconBlock<E> {
     pub fn clone_as_blinded(&self) -> SignedBlindedBeaconBlock<E> {
         SignedBeaconBlock::from_block(self.message().into(), self.signature().clone())
+    }
+}
+
+pub trait AsSignedBlock<T: EthSpec>: Debug {
+    fn block_root(&self) -> Hash256;
+    fn slot(&self) -> Slot;
+    fn epoch(&self) -> Epoch;
+    fn parent_root(&self) -> Hash256;
+    fn state_root(&self) -> Hash256;
+    fn signed_block_header(&self) -> SignedBeaconBlockHeader;
+    fn message(&self) -> BeaconBlockRef<T>;
+    fn as_block(&self) -> &SignedBeaconBlock<T>;
+    fn block_cloned(&self) -> Arc<SignedBeaconBlock<T>>;
+}
+
+impl<T: EthSpec> AsSignedBlock<T> for Arc<SignedBeaconBlock<T>> {
+    fn block_root(&self) -> Hash256 {
+        self.block_root()
+    }
+    fn slot(&self) -> Slot {
+        self.slot()
+    }
+    fn epoch(&self) -> Epoch {
+        self.epoch()
+    }
+    fn parent_root(&self) -> Hash256 {
+        self.parent_root()
+    }
+    fn state_root(&self) -> Hash256 {
+        self.state_root()
+    }
+    fn signed_block_header(&self) -> SignedBeaconBlockHeader {
+        self.signed_block_header()
+    }
+    fn message(&self) -> BeaconBlockRef<T> {
+        self.message()
+    }
+    fn as_block(&self) -> &SignedBeaconBlock<T> {
+        &*self
+    }
+    fn block_cloned(&self) -> Arc<SignedBeaconBlock<T>> {
+        self.clone()
     }
 }
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -55,7 +55,7 @@ malloc_utils = { path = "../common/malloc_utils" }
 directory = { path = "../common/directory" }
 unused_port = { path = "../common/unused_port" }
 database_manager = { path = "../database_manager" }
-slasher = { path = "../slasher" }
+slasher = { path = "../slasher", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/slasher/service/Cargo.toml
+++ b/slasher/service/Cargo.toml
@@ -9,7 +9,7 @@ beacon_chain = { path = "../../beacon_node/beacon_chain" }
 directory = { path = "../../common/directory" }
 lighthouse_network = { path = "../../beacon_node/lighthouse_network" }
 network = { path = "../../beacon_node/network" }
-slasher = { path = ".." }
+slasher = { path = "..", default-features = false }
 slog = "2.5.2"
 slot_clock = { path = "../../common/slot_clock" }
 state_processing = { path = "../../consensus/state_processing" }


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/3991

## Proposed Changes

A block with kzg commits is not available until its blobs have arrived. 
Save kzg commits against blobs verification until after execution payload verification, along with `AvailabilityPendingBlock`. 

## Additional Info

A block's execution payload has to be verified at some point before importing to fork choice. If a block sets of to get this done after it gets gossip verified and propagated, then in some cases we may be lucky that, while waiting on input from execution layer, all of our blobs came. If this is not the case, we cache the `ExecutedBlock` which holds a `DataAvailabilityHandle`, and put the sender to the `DataAvailabilityHandle` in the blobs cache.

Building on from this solution https://github.com/realbigsean/lighthouse/blob/dd3162172d676b5631005771e2cff52011cabf47/beacon_node/beacon_chain/src/blob_verification.rs#L275

I'm keeping in mind that the probability that the blocks always comes last, after all its blobs, is small, and I'm allowing therefore an efficient solution for most scenarios at the cost of a less efficient solution for the scenario that the block comes last, here:
https://github.com/emhane/lighthouse/blob/97a1847e599fccd9c8ac6cc7ba5c301e4f554b1f/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs#L665-L692